### PR TITLE
feature: Structured Records

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
 		'pyvcd>=0.2.2',
 		'Jinja2~=3.0',
 		'rich',
+		'typing-extensions',
 	],
 
 	extras_require   = {

--- a/tests/hdl/test_rec.py
+++ b/tests/hdl/test_rec.py
@@ -361,6 +361,38 @@ class RecordTestCase(ToriiTestSuiteCase):
 		self.assertEqual(repr(r1.eq(1)), '(eq (cat (sig r1__a)) (const 1\'d1))')
 		self.assertEqual(repr(r1.eq(s1)), '(eq (cat (sig r1__a)) (sig s1))')
 
+	def test_structured(self):
+		class ULPIDataRecord(Record):
+			i: Signal[8, Direction.FANIN]
+			o: Signal[8, Direction.FANOUT]
+			oe: Signal[8, Direction.FANOUT]
+
+		class ULPIDirRecord(Record):
+			i: Signal[1, Direction.FANIN]
+
+		class ULPIInterface(Record):
+			data: ULPIDataRecord
+			nxt: Signal[1, Direction.FANIN]
+			stp: Signal[1, Direction.FANOUT]
+			dir: ULPIDirRecord
+			rst: Signal[1, Direction.FANOUT]
+
+		ulpi_data = ULPIDataRecord()
+		ulpi_dir  = ULPIDirRecord()
+		ulpi_int  = ULPIInterface()
+
+		self.assertEqual(
+			repr(ulpi_data),
+			'(rec ulpi_data i o oe)'
+		)
+		self.assertEqual(
+			repr(ulpi_dir),
+			'(rec ulpi_dir i)'
+		)
+		self.assertEqual(
+			repr(ulpi_int),
+			'(rec ulpi_int (rec ulpi_int__data i o oe) nxt stp (rec ulpi_int__dir i) rst)'
+		)
 
 class ConnectTestCase(ToriiTestSuiteCase):
 	def setUp_flat(self):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -11,7 +11,10 @@ from collections.abc   import (
 )
 from enum              import Enum, EnumMeta
 from itertools         import chain
-from typing            import Optional, Union
+from typing            import Optional, Union, Generic, TYPE_CHECKING
+
+# For Python <= 3.10
+from typing_extensions import TypeVarTuple, Unpack
 
 from ..util            import flatten, tracer, union
 from ..util.decorators import final
@@ -1175,8 +1178,9 @@ class Cat(Value):
 		return f'(cat {" ".join(map(repr, self.parts))})'
 
 
+_SigParams = TypeVarTuple('_SigParams')
 # @final
-class Signal(Value, DUID):
+class Signal(Value, DUID, Generic[Unpack[_SigParams]]):
 	'''
 	A varying integer value.
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -11,7 +11,7 @@ from collections.abc   import (
 )
 from enum              import Enum, EnumMeta
 from itertools         import chain
-from typing            import Optional, Union, Generic, TYPE_CHECKING
+from typing            import Optional, Union, Generic
 
 # For Python <= 3.10
 from typing_extensions import TypeVarTuple, Unpack


### PR DESCRIPTION
This PR adds the ability for creating more type-friendly `Record` types by using `Signal` to assign a type to each member, and then on construction generate the appropriate record layout.

For example:

```python
class FooRecord(Record):
  i: Signal[8, Direction.FANIN]
  o: Signal[8, Direction.FANOUT]
  oe: Signal[8, Direction.FANOUT]
```

They can then be used in any place a normal `Record` would be.


You can also nest them, and they behave properly, e.g. 
```python
class FooRecord(Record):
  i: Signal[8, Direction.FANIN]
  o: Signal[8, Direction.FANOUT]
  oe: Signal[8, Direction.FANOUT]

class BarRecord(Record):
  foo: FooRecord
  nya: Signal[1, Direction.FANIN]
```


