### PR TITLE
torii.hdl.ast: Added `Value.inc` and `Value.dec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Unreleased template stuff
 ### Added
 
  - Added new `torii.platform.formal.FormalPlatform` for formal verification of Torii designs.
+ - Added `Value.inc()` and `Value.dec()` calls to help deal with the `sig.eq(sig + 1)` pattern that is all too common.
 
 ### Changed
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -563,6 +563,25 @@ class ValueTestCase(ToriiTestSuiteCase):
 		s = Const(10).replicate(3)
 		self.assertEqual(repr(s), '(cat (const 4\'d10) (const 4\'d10) (const 4\'d10))')
 
+	def test_inc_value(self):
+		self.assertRepr(
+			Value.cast(1).inc(),
+			'(eq (const 1\'d1) (+ (const 1\'d1) (const 1\'d1)))'
+		)
+		self.assertRepr(
+			Value.cast(1).inc(Const(4)),
+			'(eq (const 1\'d1) (+ (const 1\'d1) (const 3\'d4)))'
+		)
+
+	def test_dec_value(self):
+		self.assertRepr(
+			Value.cast(1).dec(),
+			'(eq (const 1\'d1) (- (const 1\'d1) (const 1\'d1)))'
+		)
+		self.assertRepr(
+			Value.cast(1).dec(Const(4)),
+			'(eq (const 1\'d1) (- (const 1\'d1) (const 3\'d4)))'
+		)
 
 class ConstTestCase(ToriiTestSuiteCase):
 	def test_shape(self):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -810,6 +810,46 @@ class Value(metaclass = ABCMeta):
 
 		return Assign(self, value, src_loc_at = 1)
 
+	def inc(self, value: ValueCastType = 1) -> 'Assign':
+		'''
+		Increment value.
+
+		This is shorthand for ``a.eq(a + n)``
+
+		Parameters
+		----------
+		value : Value, in
+			Value to increment by. (default: 1)
+
+		Returns
+		-------
+		Assign
+			Assignment statement that can be used in combinatorial or synchronous context.
+
+		'''
+
+		return Assign(self, self + value, src_loc_at = 1)
+
+	def dec(self, value: ValueCastType = 1) -> 'Assign':
+		'''
+		Decrement value.
+
+		This is shorthand for ``a.eq(a - n)``
+
+		Parameters
+		----------
+		value : Value, in
+			Value to decrement by. (default: 1)
+
+		Returns
+		-------
+		Assign
+			Assignment statement that can be used in combinatorial or synchronous context.
+
+		'''
+
+		return Assign(self, self - value, src_loc_at = 1)
+
 	@abstractmethod
 	def shape(self) -> Shape:
 		'''


### PR DESCRIPTION
Added `inc` and `dec`  methods to `Value` to allow for shorthand of the `signal.eq(signal + 1)` pattern commonly used throughout Torii gateware.

It's implemented effectivly as the same thing internally, and therefore should result in identical RTL.

This closes #9