### PR TITLE
Update `noxfile` to improve testing ergonomics

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           echo "$HOME/.local/bin:$PATH" >> $GITHUB_PATH
           echo "GITHUB_WORKSPACE=\"`pwd`\"" >> $GITHUB_ENV
+          echo "TORII_TEST_FORMAL=1" >> $GITHUB_ENV
 
       - name: 'Checkout'
         uses: actions/checkout@v4
@@ -43,8 +44,7 @@ jobs:
       - name: 'Run Formal Tests'
         shell: bash
         run: |
-          nox -s test -- --formal --coverage
-
+          nox -s test
       - name: 'Codecov Upload'
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
         timeout-minutes: 30 # Python 3.12 and 3.13 seem to just hang on testing ~sometimes~
         continue-on-error: ${{ matrix.python-version == '3.12' || matrix.python-version == '3.13.0-rc.2' }}
         run: |
-          nox -s test -- --coverage
+          nox -s test
 
       - name: 'Codecov Upload'
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
This PR updates the `noxfile` to use environment variables rather than an extra `-- --coverage` flag to enable coverage or `-- --formal` flag to enable formal.

Coverage is not automatically enabled if the environment variable `TORII_TEST_COVERAGE` is set or the tests are run under GitHub CI, and formal tests are ran if `TORII_TEST_FORMAL` is set.

We also now forward the extra arguments to the test command line, allowing for filtering of the tests, allowing you to only run a smaller selection of tests while working on things.