### PR TITLE
Add simple unidirectional streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Unreleased template stuff
 - Added kwargs-based constructor to `DomainRenamer` to allow for more ergonomic usage (`DomainRenamer(sync = 'pipe')`)
 - Added new library components `torii.lib.stream`
   - `torii.lib.stream.StreamInterface` - A unidirectional stream interface.
+  - `torii.lib.stream.StreamArbiter` - A simple N:1 stream arbiter for `StreamInterface`s
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Unreleased template stuff
 ### Added
 
 - Added kwargs-based constructor to `DomainRenamer` to allow for more ergonomic usage (`DomainRenamer(sync = 'pipe')`)
+- Added new library components `torii.lib.stream`
+  - `torii.lib.stream.StreamInterface` - A unidirectional stream interface.
 
 ### Changed
 

--- a/tests/lib/test_stream.py
+++ b/tests/lib/test_stream.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+from torii.lib.stream import StreamInterface
+
+from ..utils          import ToriiTestSuiteCase
+
+
+class StreamInterfaceTestCase(ToriiTestSuiteCase):
+
+	def test_record(self) -> None:
+		s0 = StreamInterface()
+		self.assertRepr(s0, '(rec s0 data valid first last ready)')
+
+		s1 = StreamInterface(extra = [('meow', 8)])
+		self.assertRepr(s1, '(rec s1 data valid first last ready meow)')
+
+		s2 = StreamInterface(name = 'ULPI')
+		self.assertRepr(s2, '(rec ULPI data valid first last ready)')
+
+
+	def test_sizes(self) -> None:
+		s0 = StreamInterface()
+		self.assertEqual(s0.data.width,  8)
+		self.assertEqual(s0.valid.width, 1)
+
+		s1 = StreamInterface(data_width = 32, valid_width = None)
+		self.assertEqual(s1.data.width,  32)
+		self.assertEqual(s1.valid.width,  4)
+
+		s2 = StreamInterface(data_width = 16, valid_width = 8)
+		self.assertEqual(s2.data.width,  16)
+		self.assertEqual(s2.valid.width,  8)

--- a/tests/lib/test_stream.py
+++ b/tests/lib/test_stream.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.lib.stream import StreamInterface
+from random           import randbytes
+
+from torii.hdl.dsl    import Module
+from torii.hdl.ir     import Elaboratable
+from torii.lib.stream import StreamInterface, StreamArbiter
+from torii.sim.core   import Settle
+from torii.test       import ToriiTestCase
 
 from ..utils          import ToriiTestSuiteCase
 
@@ -30,3 +36,178 @@ class StreamInterfaceTestCase(ToriiTestSuiteCase):
 		s2 = StreamInterface(data_width = 16, valid_width = 8)
 		self.assertEqual(s2.data.width,  16)
 		self.assertEqual(s2.valid.width,  8)
+
+# TODO(aki): This test needs more proper assertions, the problem being is it's not super easy
+#            to introspect, plus the StreamArbiter internals are actually kinda simple, so
+#            this test is mostly just based on ✨ v i b e s ✨ and looking at the VCD :v
+
+STREAM_DATA        = randbytes(512)
+STREAM_DATA_STRIDE = len(STREAM_DATA) // 4
+
+class StreamArbiterTestDUT(Elaboratable):
+	arbiter: StreamArbiter
+	s0: StreamInterface
+	s1: StreamInterface
+	s2: StreamInterface
+	s3: StreamInterface
+
+	def __init__(self) -> None:
+		self.arbiter = StreamArbiter()
+		self.s0 = StreamInterface()
+		self.s1 = StreamInterface()
+		self.s2 = StreamInterface()
+		self.s3 = StreamInterface()
+
+	def elaborate(self, _) -> Module:
+		m = Module()
+
+		m.submodules.arbiter = self.arbiter
+
+		self.arbiter.connect(self.s0)
+		self.arbiter.connect(self.s1)
+		self.arbiter.connect(self.s2)
+		self.arbiter.connect(self.s3)
+
+		return m
+
+class StreamArbiterTestCase(ToriiTestCase):
+	dut      = StreamArbiterTestDUT
+	dut_args = {}
+	domains  = (('sync', 80e6), )
+
+	@ToriiTestCase.simulation
+	def test_arbiter(self):
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def s0_feeder(self: StreamArbiterTestCase):
+			yield from self.step(5)
+			for idx in range(STREAM_DATA_STRIDE):
+				if idx == 0:
+					yield self.dut.s0.first.eq(1)
+				elif idx == STREAM_DATA_STRIDE - 1:
+					yield self.dut.s0.last.eq(1)
+				else:
+					yield self.dut.s0.first.eq(0)
+					yield self.dut.s0.last.eq(0)
+
+				if (yield self.dut.s0.ready) == 1:
+					yield self.dut.s0.data.eq(STREAM_DATA[idx])
+				yield Settle()
+				yield
+			yield self.dut.s0.first.eq(0)
+			yield self.dut.s0.last.eq(0)
+
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def s1_feeder(self: StreamArbiterTestCase):
+			yield from self.step(3)
+			for idx in range(STREAM_DATA_STRIDE):
+				if idx == 0:
+					yield self.dut.s1.first.eq(1)
+				elif idx == STREAM_DATA_STRIDE - 1:
+					yield self.dut.s1.last.eq(1)
+				else:
+					yield self.dut.s1.first.eq(0)
+					yield self.dut.s1.last.eq(0)
+
+				if (yield self.dut.s1.ready) == 1:
+					yield self.dut.s1.data.eq(STREAM_DATA[idx + STREAM_DATA_STRIDE])
+				yield Settle()
+				yield
+			yield self.dut.s1.first.eq(0)
+			yield self.dut.s1.last.eq(0)
+
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def s2_feeder(self: StreamArbiterTestCase):
+			yield from self.step(11)
+			for idx in range(STREAM_DATA_STRIDE):
+				if idx == 0:
+					yield self.dut.s2.first.eq(1)
+				elif idx == STREAM_DATA_STRIDE - 1:
+					yield self.dut.s2.last.eq(1)
+				else:
+					yield self.dut.s2.first.eq(0)
+					yield self.dut.s2.last.eq(0)
+
+				if (yield self.dut.s2.ready) == 1:
+					yield self.dut.s2.data.eq(STREAM_DATA[idx + (STREAM_DATA_STRIDE * 2)])
+				yield Settle()
+				yield
+			yield self.dut.s2.first.eq(0)
+			yield self.dut.s2.last.eq(0)
+
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def s3_feeder(self: StreamArbiterTestCase):
+			yield from self.step(1)
+			for idx in range(STREAM_DATA_STRIDE):
+				if idx == 0:
+					yield self.dut.s3.first.eq(1)
+				elif idx == STREAM_DATA_STRIDE - 1:
+					yield self.dut.s3.last.eq(1)
+				else:
+					yield self.dut.s3.first.eq(0)
+					yield self.dut.s3.last.eq(0)
+
+				if (yield self.dut.s3.ready) == 1:
+					yield self.dut.s3.data.eq(STREAM_DATA[idx + (STREAM_DATA_STRIDE * 3)])
+				yield Settle()
+				yield
+			yield self.dut.s3.first.eq(0)
+			yield self.dut.s3.last.eq(0)
+
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def stream_arbiter(self: StreamArbiterTestCase):
+			self.assertEqual((yield self.dut.arbiter.idle), 1)
+			yield self.dut.arbiter.out.ready.eq(0)
+			yield from self.step(10)
+			yield self.dut.arbiter.out.ready.eq(1)
+			yield self.dut.s0.valid.eq(1)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(1)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(1)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(1)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(1)
+			yield self.dut.s1.valid.eq(1)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(1)
+			yield self.dut.s2.valid.eq(1)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(1)
+			yield self.dut.s3.valid.eq(1)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(1)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(1)
+			yield from self.step(10)
+			yield self.dut.s0.valid.eq(0)
+			yield self.dut.s1.valid.eq(0)
+			yield self.dut.s2.valid.eq(0)
+			yield self.dut.s3.valid.eq(0)
+			yield from self.step(10)
+
+
+		s0_feeder(self)
+		s1_feeder(self)
+		s2_feeder(self)
+		s3_feeder(self)
+		stream_arbiter(self)

--- a/torii/lib/stream.py
+++ b/torii/lib/stream.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: BSD-2-Clause
+from __future__      import annotations
+
+from collections.abc import Iterable
+from warnings        import warn
+
+from ..hdl.ast       import Signal
+from ..hdl.rec       import Record
+
+
+__all__ = (
+	'StreamInterface',
+)
+
+
+class StreamInterface(Record):
+	'''
+	A simple interface representing a unidirectional stream.
+
+	Parameters
+	----------
+	data_width : int
+		The width of the stream data in bits.
+		(default: 8)
+
+	valid_width : int | None
+		The width of the valid field. If ``None`` it will default to ``data_width // 8``.
+		(default: 1)
+
+	name : str | None
+		The name of this stream.
+		(default: None)
+
+	extra : Iterable[tuple[str, int]]
+		Any extra or ancillary fields to graft on to the stream.
+		(default: [])
+
+	Attributes
+	----------
+	data : Signal(data_width), send
+		The data in the stream to be transmitted.
+
+	valid : Signal(valid_width), send
+		This can be two things, by default, when ``valid_width`` is ``data_width // 8``, it represents
+		a set of bit flags for each byte in ``data`` determining if that byte of ``data`` is valid.
+
+		For example, with ``data_width`` of ``16``, ``valid_width`` will be ``2``, where ``valid[0]`` is
+		the valid flag for ``data[0:8]`` and ``valid[1]`` is the valid flag for ``data[8:16]``.
+
+		When set to ``1`` it can simply mean that the whole of ``data`` is valid for this transaction. It
+		can be as granular or corse as you wish, as long as both sides of the stream agree.
+
+	first : Signal, send
+		Indicates that the data is the first of the current packet.
+
+	last : Signal, send
+		Indicates that the data is the last of the current packet.
+
+	ready : Signal, recv
+		Indicates that the receiver will accept the data at the next active
+		clock edge.
+
+	payload : Signal(data_width), send (alias)
+		This is a dynamic alias to the ``data`` member of the record.
+
+	'''
+
+	valid: Signal
+	ready: Signal
+	first: Signal
+	last: Signal
+	data: Signal
+
+	def __init__(
+		self, *,
+		data_width: int = 8, valid_width: int | None = 1, name: str | None = None, extra: Iterable[tuple[str, int]] = []
+	) -> None:
+
+		self._extra_fields = extra
+
+		if valid_width is None:
+			valid_width = data_width // 8
+
+		super().__init__([
+			('data',  data_width),
+			('valid', valid_width),
+			('first', 1),
+			('last',  1),
+			('ready', 1),
+			*extra
+		], name = name, src_loc_at = 1)
+
+	def attach(self, stream: StreamInterface, omit: set = set()):
+		'''
+		Attach to a target stream.
+
+		This method connects our ``valid``, ``first``, ``last``, and ``data`` fields to
+		the downstream facing ``stream``, and their ``ready`` field to ours.
+
+		This establishes a connection to where we are the originating stream, and ``stream``
+		is the receiving stream.
+
+		.. code-block::
+
+			self.data  -> stream.data
+			self.valid -> stream.valid
+			self.first -> stream.first
+			self.last  -> stream.last
+			self.ready <- stream.ready
+
+		Parameters
+		----------
+		stream : torii.lib.stream.StreamInterface
+			The stream we are attaching to.
+
+		omit : set[str]
+			A set of additional stream fields to exclude from the tap connection.
+			(default: {})
+		'''
+
+		rhs = ('valid', 'first', 'last', 'data', )
+		lhs = ('ready', )
+		att = [
+			# Connect outgoing
+			*[ stream[field].eq(self[field]) for field in rhs if field not in omit ],
+			# Connect incoming
+			*[ self[field].eq(stream[field]) for field in lhs if field not in omit ],
+		]
+
+		return att
+
+	def stream_eq(self, stream: StreamInterface, omit: set = set()):
+		'''
+		Receive from target stream.
+
+		This method connects the ``valid``, ``first``, ``last``, and ``data`` from ``stream`` to ours,
+		and our ``ready`` field to theirs.
+
+		This establishes a connection to where ``stream`` is the originating stream, and we are the receiving
+		stream.
+
+		.. code-block::
+
+			self.data  <- stream.data
+			self.valid <- stream.valid
+			self.first <- stream.first
+			self.last  <- stream.last
+			self.ready -> stream.ready
+
+		This function is effectively the inverse of :py:meth:`attach`, in fact, it's implementation
+		is just:
+
+		.. code-block:: python
+
+			stream.attach(self, ...)
+
+		It is provided as a more logical way to connect streams.
+
+		Parameters
+		----------
+		stream : torii.lib.stream.StreamInterface
+			The stream to attach to this stream.
+
+		omit : set[str]
+			A set of additional stream fields to exclude from the tap connection.
+			(default: {})
+		'''
+		return stream.attach(self, omit = omit)
+
+	def tap(self, stream: StreamInterface, *, tap_ready: bool = False, omit: set = set()):
+		'''
+		Attach a StreamInterface in read-only unidirectional tap mode.
+
+		This joints all signals from ``stream`` to their matching signals in this stream.
+
+		.. code-block::
+
+			self.data  -> stream.data
+			self.valid -> stream.valid
+			self.first -> stream.first
+			self.last  -> stream.last
+			self.ready -> stream.ready
+
+		Parameters
+		----------
+		stream : torii.lib.stream.StreamInterface
+			The stream to use as the interface to this tap.
+
+		tap_ready : bool
+			By default the ``ready`` signal is excluded from the tap, passing ``True`` here will also
+			connect that signal.
+			(default: False)
+
+		omit : set[str]
+			A set of additional stream fields to exclude from the tap connection.
+			(default: {})
+		'''
+
+		tap = self.stream_eq(stream, {'ready', *omit})
+
+		# If we are also snooping on the `ready` signal then glue that on
+		if tap_ready:
+			tap.append(self.ready.eq(stream.ready))
+
+		# Return the tap
+		return tap
+
+	def __getattr__(self, name: str):
+
+		# Re-map the `payload` alias to `data`
+		if name == 'payload':
+			warn(
+				'StreamInterface alias \'payload\' is deprecated, use \'data\' instead',
+				DeprecationWarning,
+				stacklevel = 2
+			)
+			name = 'data'
+
+		return super().__getattr__(name)


### PR DESCRIPTION
This PR adds a semi-modified version of the streams present in [SOL] as a core library component. 

The one big change is the renaming of the `payload` field to be `data`.

This closes #18

[SOL]: https://github.com/shrine-maiden-heavy-industries/sol
