### PR TITLE
Add deprecation notice for root module HDL imports

### DIFF
--- a/torii/__init__.py
+++ b/torii/__init__.py
@@ -5,12 +5,8 @@ try:
 except ImportError: # :nocov:
 	__version__ = 'unknown'
 
-from .hdl import (
-	Array, Cat, ClockDomain, ClockSignal, Const, DomainRenamer,
-	Elaboratable, EnableInserter, Fragment, Instance, Memory,
-	Module, Mux, Record, ResetInserter, ResetSignal, Shape,
-	Signal, Value, signed, unsigned
-)
+from warnings  import warn
+from importlib import import_module
 
 __all__ = (
 	'Array',
@@ -35,3 +31,16 @@ __all__ = (
 	'unsigned',
 	'Value',
 )
+
+def __dir__() -> list[str]:
+	return list({*globals(), *__all__, '__version__'})
+
+def __getattr__(name: str):
+	if name in __all__:
+		warn(
+			'Importing HDL constructs from the root Torii module is deprecated, please import from `torii.hdl` instead',
+			DeprecationWarning
+		)
+		return import_module('.hdl', __name__).__dict__[name]
+	if name not in __dir__():
+		raise AttributeError(f'Module {__name__!r} has not attribute {name!r}')


### PR DESCRIPTION
This PR adds deprecation warnings for any hdl imports from the root module. 

Partially addresses #29, will remove after `0.8.0` (see #36)