### PR TITLE
Remove glob imports

### DIFF
--- a/docs/_code/led_blinker.py
+++ b/docs/_code/led_blinker.py
@@ -1,4 +1,4 @@
-from torii import *
+from torii import Elaboratable, Module, Signal
 
 class LEDBlinker(Elaboratable):
     def elaborate(self, platform):

--- a/docs/_code/up_counter.py
+++ b/docs/_code/up_counter.py
@@ -1,4 +1,4 @@
-from torii import *
+from torii import Elaboratable, Module, Signal
 
 class UpCounter(Elaboratable):
     '''
@@ -40,7 +40,7 @@ class UpCounter(Elaboratable):
 
         return m
 # --- TEST ---
-from torii.sim import Simulator
+from torii.sim import Simulator # noqa: E402
 
 dut = UpCounter(25)
 def bench():
@@ -68,7 +68,7 @@ sim.add_sync_process(bench)
 with sim.write_vcd('up_counter.vcd'):
     sim.run()
 # --- CONVERT ---
-from torii.back import verilog  # noqa: E402
+from torii.back import verilog # noqa: E402
 
 top = UpCounter(25)
 with open('up_counter.v', 'w') as f:

--- a/tests/build/test_dsl.py
+++ b/tests/build/test_dsl.py
@@ -2,7 +2,9 @@
 
 from collections     import OrderedDict
 
-from torii.build.dsl import *
+from torii.build.dsl import (
+	Attrs, Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Resource, Subsignal,
+)
 
 from ..utils         import ToriiTestSuiteCase
 

--- a/tests/build/test_plat.py
+++ b/tests/build/test_plat.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii            import *
-from torii.build.plat import *
+from torii.build.plat import Platform
 
 from ..utils          import ToriiTestSuiteCase
 

--- a/tests/build/test_res.py
+++ b/tests/build/test_res.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii           import *
-from torii.hdl.rec   import *
-from torii.lib.io    import *
-from torii.build.dsl import *
-from torii.build.res import *
+from torii.build.dsl import Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Subsignal
+from torii.build.res import Resource, ResourceError, ResourceManager
+from torii.hdl.ast   import Signal
+from torii.hdl.rec   import Record
+from torii.lib.io    import Pin
 
 from ..utils         import ToriiTestSuiteCase
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -4,7 +4,10 @@ import warnings
 from enum          import Enum, EnumMeta
 from sys           import version_info
 
-from torii.hdl.ast import *
+from torii.hdl.ast import (
+	Array, Cat, ClockSignal, Const, Initial, Mux, Part, ResetSignal, Sample, Shape, ShapeCastable, ShapeLike,
+	Signal, Slice, Switch, Value, ValueCastable, ValueLike, signed, unsigned,
+)
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/hdl/test_cd.py
+++ b/tests/hdl/test_cd.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.hdl.cd import *
+from torii.hdl.cd import ClockDomain
 
 from ..utils      import ToriiTestSuiteCase
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -6,9 +6,9 @@ from collections   import OrderedDict
 from enum          import Enum
 from sys           import version_info
 
-from torii.hdl.ast import *
-from torii.hdl.cd  import *
-from torii.hdl.dsl import *
+from torii.hdl.ast import Cat, ClockSignal, Past, ResetSignal, Signal, SignalSet, Switch
+from torii.hdl.cd  import ClockDomain
+from torii.hdl.dsl import Module, SyntaxError, SyntaxWarning
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/hdl/test_ir.py
+++ b/tests/hdl/test_ir.py
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from collections   import OrderedDict
+from collections           import OrderedDict
 
-from torii.hdl.ast import *
-from torii.hdl.cd  import *
-from torii.hdl.ir  import *
-from torii.hdl.mem import *
-from torii.tools   import ToolNotFound
+from torii.hdl.ast         import Cat, ClockSignal, Const, ResetSignal, Signal, SignalDict, SignalKey, SignalSet
+from torii.hdl.cd          import ClockDomain, DomainError
+from torii.hdl.dsl         import Module
+from torii.hdl.ir          import DriverConflict, Elaboratable, Fragment, Instance
+from torii.platform.formal import FormalPlatform
+from torii.tools           import ToolNotFound
 
-from ..utils       import ToriiTestSuiteCase
+from ..utils               import ToriiTestSuiteCase
 
 class ElaboratesToNone(Elaboratable):
 	def elaborate(self, platform):
@@ -942,9 +943,6 @@ class InstanceTestCase(ToriiTestSuiteCase):
 
 class ElaboratableTestCase(ToriiTestSuiteCase):
 	def test_formal_on_nonformal_elaboratable(self):
-		from torii                 import Module
-		from torii.platform.formal import FormalPlatform
-
 		class SimpleElaboratable(Elaboratable):
 			def elaborate(self, _):
 				m = Module()

--- a/tests/hdl/test_mem.py
+++ b/tests/hdl/test_mem.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl.ast import *
-from torii.hdl.mem import *
+from torii.hdl.ast import Const, Signal
+from torii.hdl.mem import DummyPort, Memory
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/hdl/test_rec.py
+++ b/tests/hdl/test_rec.py
@@ -2,8 +2,8 @@
 
 from enum          import Enum
 
-from torii.hdl.ast import *
-from torii.hdl.rec import *
+from torii.hdl.ast import Shape, Signal, signed, unsigned
+from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/hdl/test_xfrm.py
+++ b/tests/hdl/test_xfrm.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl.ast  import *
-from torii.hdl.cd   import *
+from torii.hdl.ast  import Cat, ClockSignal, ResetSignal, Sample, Signal, SignalSet, Switch
+from torii.hdl.cd   import ClockDomain, DomainError
 from torii.hdl.dsl  import Module
-from torii.hdl.ir   import *
-from torii.hdl.mem  import *
-from torii.hdl.mem  import MemoryInstance
-from torii.hdl.xfrm import *
+from torii.hdl.ir   import Elaboratable, Fragment
+from torii.hdl.mem  import Memory, MemoryInstance
+from torii.hdl.xfrm import (
+	DomainLowerer, DomainRenamer, EnableInserter, LHSGroupAnalyzer, LHSGroupFilter, ResetInserter,
+	SampleLowerer, SwitchCleaner, TransformedElaboratable,
+)
 
-from ..utils        import ToriiTestSuiteCase
+from ..utils import ToriiTestSuiteCase
 
 class DomainRenamerTestCase(ToriiTestSuiteCase):
 	def setUp(self):

--- a/tests/lib/coding/test_gray.py
+++ b/tests/lib/coding/test_gray.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl             import *
+from torii.hdl.dsl         import Module
+from torii.hdl.ir          import Elaboratable
 from torii.lib.coding.gray import Decoder, Encoder
 from torii.lib.formal      import Assert, Assume
-from torii.sim             import *
 
 from ...utils              import ToriiTestSuiteCase
 

--- a/tests/lib/coding/test_one_hot.py
+++ b/tests/lib/coding/test_one_hot.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl                import *
 from torii.lib.coding.one_hot import Decoder, Encoder
-from torii.sim                import *
+from torii.sim                import Settle, Simulator
 
 from ...utils                 import ToriiTestSuiteCase
 

--- a/tests/lib/coding/test_priotity.py
+++ b/tests/lib/coding/test_priotity.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl                 import *
 from torii.lib.coding.priority import Encoder
-from torii.sim                 import *
+from torii.sim                 import Settle, Simulator
 
 from ...utils                  import ToriiTestSuiteCase
 

--- a/tests/lib/soc/csr/test_bus.py
+++ b/tests/lib/soc/csr/test_bus.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii                 import *
+from torii.hdl.dsl         import Module
 from torii.hdl.rec         import Layout
-from torii.lib.soc.csr.bus import *
+from torii.hdl.ir          import Fragment
+from torii.lib.soc.csr.bus import Decoder, Element, Interface, Multiplexer
 from torii.lib.soc.memory  import MemoryMap
-from torii.sim             import *
+from torii.sim             import Delay, Simulator
 
 from ....utils             import ToriiTestSuiteCase
 

--- a/tests/lib/soc/csr/test_event.py
+++ b/tests/lib/soc/csr/test_event.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii             import *
 from torii.lib.soc     import event
-from torii.lib.soc.csr import *
-from torii.sim         import *
+from torii.lib.soc.csr import Element, EventMonitor
+from torii.sim         import Delay, Simulator
 
 from ....utils         import ToriiTestSuiteCase
 

--- a/tests/lib/soc/csr/test_wishbone.py
+++ b/tests/lib/soc/csr/test_wishbone.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii                      import *
+from torii.hdl.ast              import Signal
+from torii.hdl.dsl              import Module
+from torii.hdl.ir               import Elaboratable
 from torii.lib.soc              import csr
-from torii.lib.soc.csr.wishbone import *
-from torii.sim                  import *
+from torii.lib.soc.csr.wishbone import WishboneCSRBridge
+from torii.sim                  import Simulator
 
 from ....utils                  import ToriiTestSuiteCase
 

--- a/tests/lib/soc/test_event.py
+++ b/tests/lib/soc/test_event.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii               import *
-from torii.lib.soc.event import *
-from torii.sim           import *
+from torii.lib.soc.event import EventMap, Monitor, Source
+from torii.sim           import Simulator
 
 from ...utils            import ToriiTestSuiteCase
 

--- a/tests/lib/soc/test_periph.py
+++ b/tests/lib/soc/test_periph.py
@@ -2,7 +2,7 @@
 
 from torii.lib.soc        import event
 from torii.lib.soc.memory import MemoryMap
-from torii.lib.soc.periph import *
+from torii.lib.soc.periph import ConstantBool, ConstantInt, ConstantMap, PeripheralInfo
 
 from ...utils             import ToriiTestSuiteCase
 

--- a/tests/lib/soc/wishbone/test_bus.py
+++ b/tests/lib/soc/wishbone/test_bus.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii                      import *
-from torii.hdl.rec              import *
+from torii.hdl.dsl              import Module
+from torii.hdl.ir               import Elaboratable
+from torii.hdl.rec              import DIR_FANIN, DIR_FANOUT, Layout
 from torii.lib.soc.memory       import MemoryMap
-from torii.lib.soc.wishbone.bus import *
-from torii.sim                  import *
+from torii.lib.soc.wishbone.bus import Arbiter, BurstTypeExt, CycleType, Decoder, Interface
+from torii.sim                  import Delay, Simulator, Tick
 
 from ....utils                  import ToriiTestSuiteCase
 

--- a/tests/lib/stdio/test_serial.py
+++ b/tests/lib/stdio/test_serial.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii                  import *
+from torii.hdl.dsl          import Module
+from torii.hdl.rec          import Record
 from torii.lib.fifo         import SyncFIFO
 from torii.lib.io           import pin_layout
-from torii.lib.stdio.serial import *
-from torii.sim              import *
+from torii.lib.stdio.serial import AsyncSerial, AsyncSerialRX, AsyncSerialTX
+from torii.sim              import Simulator
 
 from ...utils               import ToriiTestSuiteCase
+
 
 def simulation_test(dut, process):
 	sim = Simulator(dut)

--- a/tests/lib/stdio/test_serial.py
+++ b/tests/lib/stdio/test_serial.py
@@ -10,7 +10,6 @@ from torii.sim              import Simulator
 
 from ...utils               import ToriiTestSuiteCase
 
-
 def simulation_test(dut, process):
 	sim = Simulator(dut)
 	with sim.write_vcd('test.vcd'):

--- a/tests/lib/test_cdc.py
+++ b/tests/lib/test_cdc.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl     import *
-from torii.lib.cdc import *
-from torii.sim     import *
+from torii.hdl.ast import Signal
+from torii.hdl.cd  import ClockDomain
+from torii.hdl.dsl import Module
+from torii.lib.cdc import AsyncFFSynchronizer, FFSynchronizer, PulseSynchronizer, ResetSynchronizer
+from torii.sim     import Delay, Simulator, Tick
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/lib/test_fifo.py
+++ b/tests/lib/test_fifo.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl        import *
-from torii.lib.fifo   import *
-from torii.lib.formal import *
-from torii.sim        import *
+from torii.hdl.ast  import AnyConst, Assert, Assume, ClockSignal, Initial, Past, ResetSignal, Rose, Signal
+from torii.hdl.cd   import ClockDomain
+from torii.hdl.dsl  import Module
+from torii.hdl.ir   import Elaboratable
+from torii.hdl.mem  import Memory
+from torii.lib.fifo import AsyncFIFO, AsyncFIFOBuffered, FIFOInterface, SyncFIFO, SyncFIFOBuffered
+from torii.sim      import Simulator, Tick
 
-from ..utils          import ToriiTestSuiteCase
+from ..utils        import ToriiTestSuiteCase
 
 class FIFOTestCase(ToriiTestSuiteCase):
 	def test_depth_wrong(self):

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.hdl     import *
-from torii.hdl.rec import *
-from torii.lib.io  import *
-from torii.sim     import *
+from torii.hdl.ast import Shape, unsigned
+from torii.hdl.rec import DIR_NONE
+from torii.lib.io  import Pin, pin_layout
 
 from ..utils       import ToriiTestSuiteCase
 

--- a/tests/lib/test_scheduler.py
+++ b/tests/lib/test_scheduler.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.hdl           import *
-from torii.lib.scheduler import *
-from torii.sim           import *
+from torii.lib.scheduler import RoundRobin
+from torii.sim           import Delay, Simulator
 
 from ..utils             import ToriiTestSuiteCase
 

--- a/tests/sim/test_sim.py
+++ b/tests/sim/test_sim.py
@@ -18,7 +18,6 @@ from torii.util    import flatten
 
 from ..utils       import ToriiTestSuiteCase
 
-
 class SimulatorUnitTestCase(ToriiTestSuiteCase):
 	def assertStatement(self, stmt, inputs, output, reset = 0):
 		inputs = [Value.cast(i) for i in inputs]

--- a/tests/sim/test_sim.py
+++ b/tests/sim/test_sim.py
@@ -5,16 +5,19 @@ import os
 from contextlib    import contextmanager
 from warnings      import catch_warnings
 
-from torii.hdl.ast import *
-from torii.hdl.cd  import *
-from torii.hdl.dsl import *
-from torii.hdl.ir  import *
-from torii.hdl.mem import *
-from torii.hdl.rec import *
-from torii.sim     import *
+from torii.hdl.ast import (
+	Array, Cat, Const, Fell, Mux, Past, Rose, Signal, Stable, Value, ValueCastable, signed, unsigned,
+)
+from torii.hdl.cd  import ClockDomain
+from torii.hdl.dsl import Module, Statement
+from torii.hdl.ir  import Fragment
+from torii.hdl.mem import Memory
+from torii.hdl.rec import Record
+from torii.sim     import Delay, Passive, Settle, Simulator, Tick
 from torii.util    import flatten
 
-from ..utils       import *
+from ..utils       import ToriiTestSuiteCase
+
 
 class SimulatorUnitTestCase(ToriiTestSuiteCase):
 	def assertStatement(self, stmt, inputs, output, reset = 0):

--- a/tests/util/test_tracer.py
+++ b/tests/util/test_tracer.py
@@ -3,7 +3,7 @@
 from types         import SimpleNamespace
 
 from torii.hdl     import ast
-from torii.hdl.ast import *
+from torii.hdl.ast import Signal
 from torii.test    import ToriiTestCase
 
 class TracerTestCase(ToriiTestCase):


### PR DESCRIPTION
This PR removes all instances of glob imports in the codebase, as they are bad form.