### PR TITLE
Deprecate `DIR_NONE`, `DIR_FANIN` and `DIR_FANOUT` constants in favor of proper `Direction` enumeration access.

### DIFF
--- a/tests/hdl/test_rec.py
+++ b/tests/hdl/test_rec.py
@@ -3,7 +3,7 @@
 from enum          import Enum
 
 from torii.hdl.ast import Shape, Signal, signed, unsigned
-from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
+from torii.hdl.rec import Direction, Layout, Record
 
 from ..utils       import ToriiTestSuiteCase
 
@@ -22,36 +22,36 @@ class LayoutTestCase(ToriiTestSuiteCase):
 		layout = Layout.cast([
 			('cyc',  1),
 			('data', signed(32)),
-			('stb',  1, DIR_FANOUT),
-			('ack',  1, DIR_FANIN),
+			('stb',  1, Direction.FANOUT),
+			('ack',  1, Direction.FANIN),
 			('info', [
 				('a', 1),
 				('b', 1),
 			])
 		])
 
-		self.assertFieldEqual(layout['cyc'], (unsigned(1), DIR_NONE))
-		self.assertFieldEqual(layout['data'], (signed(32), DIR_NONE))
-		self.assertFieldEqual(layout['stb'], (unsigned(1), DIR_FANOUT))
-		self.assertFieldEqual(layout['ack'], (unsigned(1), DIR_FANIN))
+		self.assertFieldEqual(layout['cyc'], (unsigned(1), Direction.NONE))
+		self.assertFieldEqual(layout['data'], (signed(32), Direction.NONE))
+		self.assertFieldEqual(layout['stb'], (unsigned(1), Direction.FANOUT))
+		self.assertFieldEqual(layout['ack'], (unsigned(1), Direction.FANIN))
 		sublayout = layout['info'][0]
-		self.assertEqual(layout['info'][1], DIR_NONE)
-		self.assertFieldEqual(sublayout['a'], (unsigned(1), DIR_NONE))
-		self.assertFieldEqual(sublayout['b'], (unsigned(1), DIR_NONE))
+		self.assertEqual(layout['info'][1], Direction.NONE)
+		self.assertFieldEqual(sublayout['a'], (unsigned(1), Direction.NONE))
+		self.assertFieldEqual(sublayout['b'], (unsigned(1), Direction.NONE))
 
 	def test_enum_field(self):
 		layout = Layout.cast([
 			('enum', UnsignedEnum),
-			('enum_dir', UnsignedEnum, DIR_FANOUT),
+			('enum_dir', UnsignedEnum, Direction.FANOUT),
 		])
-		self.assertFieldEqual(layout['enum'], (unsigned(2), DIR_NONE))
-		self.assertFieldEqual(layout['enum_dir'], (unsigned(2), DIR_FANOUT))
+		self.assertFieldEqual(layout['enum'], (unsigned(2), Direction.NONE))
+		self.assertFieldEqual(layout['enum_dir'], (unsigned(2), Direction.FANOUT))
 
 	def test_range_field(self):
 		layout = Layout.cast([
 			('range', range(0, 7)),
 		])
-		self.assertFieldEqual(layout['range'], (unsigned(3), DIR_NONE))
+		self.assertFieldEqual(layout['range'], (unsigned(3), Direction.NONE))
 
 	def test_slice_tuple(self):
 		layout = Layout.cast([
@@ -103,7 +103,7 @@ class LayoutTestCase(ToriiTestSuiteCase):
 		with self.assertRaisesRegex(
 			TypeError, (
 				r'^Field \(\'a\', 1, 0\) has invalid direction: should be a Direction '
-				r'instance like DIR_FANIN$'
+				r'instance like Direction.FANIN$'
 			)
 		):
 			Layout.cast([('a', 1, 0)])
@@ -394,29 +394,29 @@ class RecordTestCase(ToriiTestSuiteCase):
 class ConnectTestCase(ToriiTestSuiteCase):
 	def setUp_flat(self):
 		self.core_layout = [
-			('addr',   32, DIR_FANOUT),
-			('data_r', 32, DIR_FANIN),
-			('data_w', 32, DIR_FANIN),
+			('addr',   32, Direction.FANOUT),
+			('data_r', 32, Direction.FANIN),
+			('data_w', 32, Direction.FANIN),
 		]
 		self.periph_layout = [
-			('addr',   32, DIR_FANOUT),
-			('data_r', 32, DIR_FANIN),
-			('data_w', 32, DIR_FANIN),
+			('addr',   32, Direction.FANOUT),
+			('data_r', 32, Direction.FANIN),
+			('data_w', 32, Direction.FANIN),
 		]
 
 	def setUp_nested(self):
 		self.core_layout = [
-			('addr',   32, DIR_FANOUT),
+			('addr',   32, Direction.FANOUT),
 			('data', [
-				('r',  32, DIR_FANIN),
-				('w',  32, DIR_FANIN),
+				('r',  32, Direction.FANIN),
+				('w',  32, Direction.FANIN),
 			]),
 		]
 		self.periph_layout = [
-			('addr',   32, DIR_FANOUT),
+			('addr',   32, Direction.FANOUT),
 			('data', [
-				('r',  32, DIR_FANIN),
-				('w',  32, DIR_FANIN),
+				('r',  32, Direction.FANIN),
+				('w',  32, Direction.FANIN),
 			]),
 		]
 
@@ -507,7 +507,7 @@ class ConnectTestCase(ToriiTestSuiteCase):
 			recs[0].connect(recs[1])
 
 	def test_wrong_missing_field(self):
-		core   = Record([('addr', 32, DIR_FANOUT)])
+		core   = Record([('addr', 32, Direction.FANOUT)])
 		periph = Record([])
 
 		with self.assertRaisesRegex(

--- a/tests/lib/soc/wishbone/test_bus.py
+++ b/tests/lib/soc/wishbone/test_bus.py
@@ -3,7 +3,7 @@
 
 from torii.hdl.dsl              import Module
 from torii.hdl.ir               import Elaboratable
-from torii.hdl.rec              import DIR_FANIN, DIR_FANOUT, Layout
+from torii.hdl.rec              import Direction, Layout
 from torii.lib.soc.memory       import MemoryMap
 from torii.lib.soc.wishbone.bus import Arbiter, BurstTypeExt, CycleType, Decoder, Interface
 from torii.sim                  import Delay, Simulator, Tick
@@ -17,14 +17,14 @@ class InterfaceTestCase(ToriiTestSuiteCase):
 		self.assertEqual(iface.data_width, 8)
 		self.assertEqual(iface.granularity, 8)
 		self.assertEqual(iface.layout, Layout.cast([
-			('adr',   32, DIR_FANOUT),
-			('dat_w', 8,  DIR_FANOUT),
-			('dat_r', 8,  DIR_FANIN),
-			('sel',   1,  DIR_FANOUT),
-			('cyc',   1,  DIR_FANOUT),
-			('stb',   1,  DIR_FANOUT),
-			('we',    1,  DIR_FANOUT),
-			('ack',   1,  DIR_FANIN),
+			('adr',   32, Direction.FANOUT),
+			('dat_w', 8,  Direction.FANOUT),
+			('dat_r', 8,  Direction.FANIN),
+			('sel',   1,  Direction.FANOUT),
+			('cyc',   1,  Direction.FANOUT),
+			('stb',   1,  Direction.FANOUT),
+			('we',    1,  Direction.FANOUT),
+			('ack',   1,  Direction.FANIN),
 		]))
 
 	def test_granularity(self):
@@ -33,14 +33,14 @@ class InterfaceTestCase(ToriiTestSuiteCase):
 		self.assertEqual(iface.data_width, 32)
 		self.assertEqual(iface.granularity, 8)
 		self.assertEqual(iface.layout, Layout.cast([
-			('adr',   30, DIR_FANOUT),
-			('dat_w', 32, DIR_FANOUT),
-			('dat_r', 32, DIR_FANIN),
-			('sel',   4,  DIR_FANOUT),
-			('cyc',   1,  DIR_FANOUT),
-			('stb',   1,  DIR_FANOUT),
-			('we',    1,  DIR_FANOUT),
-			('ack',   1,  DIR_FANIN),
+			('adr',   30, Direction.FANOUT),
+			('dat_w', 32, Direction.FANOUT),
+			('dat_r', 32, Direction.FANIN),
+			('sel',   4,  Direction.FANOUT),
+			('cyc',   1,  Direction.FANOUT),
+			('stb',   1,  Direction.FANOUT),
+			('we',    1,  Direction.FANOUT),
+			('ack',   1,  Direction.FANIN),
 		]))
 
 	def test_features(self):
@@ -49,20 +49,20 @@ class InterfaceTestCase(ToriiTestSuiteCase):
 			features = {'rty', 'err', 'stall', 'lock', 'cti', 'bte'}
 		)
 		self.assertEqual(iface.layout, Layout.cast([
-			('adr',   32, DIR_FANOUT),
-			('dat_w', 32, DIR_FANOUT),
-			('dat_r', 32, DIR_FANIN),
-			('sel',   1,  DIR_FANOUT),
-			('cyc',   1,  DIR_FANOUT),
-			('stb',   1,  DIR_FANOUT),
-			('we',    1,  DIR_FANOUT),
-			('ack',   1,  DIR_FANIN),
-			('err',   1,  DIR_FANIN),
-			('rty',   1,  DIR_FANIN),
-			('stall', 1,  DIR_FANIN),
-			('lock',  1,  DIR_FANOUT),
-			('cti',   CycleType,    DIR_FANOUT),
-			('bte',   BurstTypeExt, DIR_FANOUT),
+			('adr',   32, Direction.FANOUT),
+			('dat_w', 32, Direction.FANOUT),
+			('dat_r', 32, Direction.FANIN),
+			('sel',   1,  Direction.FANOUT),
+			('cyc',   1,  Direction.FANOUT),
+			('stb',   1,  Direction.FANOUT),
+			('we',    1,  Direction.FANOUT),
+			('ack',   1,  Direction.FANIN),
+			('err',   1,  Direction.FANIN),
+			('rty',   1,  Direction.FANIN),
+			('stall', 1,  Direction.FANIN),
+			('lock',  1,  Direction.FANOUT),
+			('cti',   CycleType,    Direction.FANOUT),
+			('bte',   BurstTypeExt, Direction.FANOUT),
 		]))
 
 	def test_wrong_addr_width(self):

--- a/tests/lib/test_io.py
+++ b/tests/lib/test_io.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from torii.hdl.ast import Shape, unsigned
-from torii.hdl.rec import DIR_NONE
+from torii.hdl.rec import Direction
 from torii.lib.io  import Pin, pin_layout
 
 from ..utils       import ToriiTestSuiteCase
@@ -18,183 +18,183 @@ class PinLayoutCombTestCase(PinLayoutTestCase):
 	def test_pin_layout_i(self):
 		layout_1 = pin_layout(1, dir = 'i')
 		self.assertLayoutEqual(layout_1.fields, {
-			'i': (unsigned(1), DIR_NONE),
+			'i': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'i')
 		self.assertLayoutEqual(layout_2.fields, {
-			'i': (unsigned(2), DIR_NONE),
+			'i': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_o(self):
 		layout_1 = pin_layout(1, dir = 'o')
 		self.assertLayoutEqual(layout_1.fields, {
-			'o': (unsigned(1), DIR_NONE),
+			'o': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'o')
 		self.assertLayoutEqual(layout_2.fields, {
-			'o': (unsigned(2), DIR_NONE),
+			'o': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_oe(self):
 		layout_1 = pin_layout(1, dir = 'oe')
 		self.assertLayoutEqual(layout_1.fields, {
-			'o':  (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o':  (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'oe')
 		self.assertLayoutEqual(layout_2.fields, {
-			'o':  (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o':  (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 	def test_pin_layout_io(self):
 		layout_1 = pin_layout(1, dir = 'io')
 		self.assertLayoutEqual(layout_1.fields, {
-			'i':  (unsigned(1), DIR_NONE),
-			'o':  (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i':  (unsigned(1), Direction.NONE),
+			'o':  (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'io')
 		self.assertLayoutEqual(layout_2.fields, {
-			'i':  (unsigned(2), DIR_NONE),
-			'o':  (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i':  (unsigned(2), Direction.NONE),
+			'o':  (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 class PinLayoutSDRTestCase(PinLayoutTestCase):
 	def test_pin_layout_i(self):
 		layout_1 = pin_layout(1, dir = 'i', xdr = 1)
 		self.assertLayoutEqual(layout_1.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'i', xdr = 1)
 		self.assertLayoutEqual(layout_2.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i': (unsigned(2), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_o(self):
 		layout_1 = pin_layout(1, dir = 'o', xdr = 1)
 		self.assertLayoutEqual(layout_1.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'o', xdr = 1)
 		self.assertLayoutEqual(layout_2.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o': (unsigned(2), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_oe(self):
 		layout_1 = pin_layout(1, dir = 'oe', xdr = 1)
 		self.assertLayoutEqual(layout_1.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o':  (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o':  (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'oe', xdr = 1)
 		self.assertLayoutEqual(layout_2.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o':  (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o':  (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 	def test_pin_layout_io(self):
 		layout_1 = pin_layout(1, dir = 'io', xdr = 1)
 		self.assertLayoutEqual(layout_1.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i':  (unsigned(1), DIR_NONE),
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o':  (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i':  (unsigned(1), Direction.NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o':  (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'io', xdr = 1)
 		self.assertLayoutEqual(layout_2.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i':  (unsigned(2), DIR_NONE),
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o':  (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i':  (unsigned(2), Direction.NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o':  (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 class PinLayoutDDRTestCase(PinLayoutTestCase):
 	def test_pin_layout_i(self):
 		layout_1 = pin_layout(1, dir = 'i', xdr = 2)
 		self.assertLayoutEqual(layout_1.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i0': (unsigned(1), DIR_NONE),
-			'i1': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i0': (unsigned(1), Direction.NONE),
+			'i1': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'i', xdr = 2)
 		self.assertLayoutEqual(layout_2.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i0': (unsigned(2), DIR_NONE),
-			'i1': (unsigned(2), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i0': (unsigned(2), Direction.NONE),
+			'i1': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_o(self):
 		layout_1 = pin_layout(1, dir = 'o', xdr = 2)
 		self.assertLayoutEqual(layout_1.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(1), DIR_NONE),
-			'o1': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(1), Direction.NONE),
+			'o1': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'o', xdr = 2)
 		self.assertLayoutEqual(layout_2.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(2), DIR_NONE),
-			'o1': (unsigned(2), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(2), Direction.NONE),
+			'o1': (unsigned(2), Direction.NONE),
 		})
 
 	def test_pin_layout_oe(self):
 		layout_1 = pin_layout(1, dir = 'oe', xdr = 2)
 		self.assertLayoutEqual(layout_1.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(1), DIR_NONE),
-			'o1': (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(1), Direction.NONE),
+			'o1': (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'oe', xdr = 2)
 		self.assertLayoutEqual(layout_2.fields, {
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(2), DIR_NONE),
-			'o1': (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(2), Direction.NONE),
+			'o1': (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 	def test_pin_layout_io(self):
 		layout_1 = pin_layout(1, dir = 'io', xdr = 2)
 		self.assertLayoutEqual(layout_1.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i0': (unsigned(1), DIR_NONE),
-			'i1': (unsigned(1), DIR_NONE),
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(1), DIR_NONE),
-			'o1': (unsigned(1), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i0': (unsigned(1), Direction.NONE),
+			'i1': (unsigned(1), Direction.NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(1), Direction.NONE),
+			'o1': (unsigned(1), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 		layout_2 = pin_layout(2, dir = 'io', xdr = 2)
 		self.assertLayoutEqual(layout_2.fields, {
-			'i_clk': (unsigned(1), DIR_NONE),
-			'i0': (unsigned(2), DIR_NONE),
-			'i1': (unsigned(2), DIR_NONE),
-			'o_clk': (unsigned(1), DIR_NONE),
-			'o0': (unsigned(2), DIR_NONE),
-			'o1': (unsigned(2), DIR_NONE),
-			'oe': (unsigned(1), DIR_NONE),
+			'i_clk': (unsigned(1), Direction.NONE),
+			'i0': (unsigned(2), Direction.NONE),
+			'i1': (unsigned(2), Direction.NONE),
+			'o_clk': (unsigned(1), Direction.NONE),
+			'o0': (unsigned(2), Direction.NONE),
+			'o1': (unsigned(2), Direction.NONE),
+			'oe': (unsigned(1), Direction.NONE),
 		})
 
 class PinTestCase(ToriiTestSuiteCase):

--- a/torii/hdl/rec.py
+++ b/torii/hdl/rec.py
@@ -13,7 +13,7 @@ from warnings        import warn
 from ..util          import tracer, union
 from .ast            import Cat, Shape, ShapeCastT, Signal, SignalSet, Value, ValueCastable
 
-__all__ = (
+__all__ = ( # noqa: F822
 	'DIR_FANIN',
 	'DIR_FANOUT',
 	'DIR_NONE',

--- a/torii/test/mock.py
+++ b/torii/test/mock.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from ..hdl.rec import DIR_FANIN, DIR_FANOUT, Record
+from ..hdl.rec import Direction, Record
 
 __all__ = (
 	'MockPlatform',
@@ -46,8 +46,8 @@ class MockRecord(Record):
 		'''
 
 		self.fields[item] = Record((
-			('o', 1, DIR_FANOUT),
-			('i', 1, DIR_FANIN )
+			('o', 1, Direction.FANOUT),
+			('i', 1, Direction.FANIN )
 		), name = f'{item}')
 
 	def __init__(self, *args, **kwargs) -> None:


### PR DESCRIPTION
This PR retains the constants, but emits a `DeprecationWarning` on import of `DIR_NONE`, `DIR_FANIN` and `DIR_FANOUT` to suggest using the appropriate `Direction.<NAME>` enum value.

For instance, having the import line like below:

```py
from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
```

Will result in the following deprecation warnings

```
test.py:1: DeprecationWarning: Use of the 'DIR_FANIN' alias is deprecated, please use 'Direction.FANIN' instead
  from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
test.py:1: DeprecationWarning: Use of the 'DIR_FANOUT' alias is deprecated, please use 'Direction.FANOUT' instead
  from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
test.py:1: DeprecationWarning: Use of the 'DIR_NONE' alias is deprecated, please use 'Direction.NONE' instead
  from torii.hdl.rec import DIR_FANIN, DIR_FANOUT, DIR_NONE, Direction, Layout, Record
```

This closes #35 