### PR TITLE
Fix: Serial nomenclature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Unreleased template stuff
 - The `torii.util.decorators.memoize` decorator has been deprecated in favor of `functools.cache`.
 - The `torii.util.decorators.extend` decorator has been deprecated and is slated for removal.
 - The `torii.tools.cxx.build_cxx` function is deprecated in favor of the `torii.tools.cxx.compile_cxx` function replacement.
+- The `rdy` and `ack` signals inside `torii.lib.stdio.AsyncSerialRx` have been renamed to `done` and `start` to better align with their function.
 
 ### Removed
 

--- a/torii/lib/stdio/serial.py
+++ b/torii/lib/stdio/serial.py
@@ -87,9 +87,10 @@ class AsyncSerialRX(Elaboratable):
 	ack : Signal, in
 		Read acknowledge. Must be held asserted while data can be read out of the receiver. (deprecated use `start`)
 	done : Signal, out
-		Read strobe.
+		Strobe that indicates we successfully completed receiving a frame of data.
 	start : Signal, in
-		Read acknowledge. Must be held asserted while data can be read out of the receiver.
+		Indication from the driving gateware that it is interested in new data from the receiver.
+		Must be held asserted to indicate reception is okay.
 	i : Signal, in
 		Serial input. If ``pins`` has been specified, ``pins.rx.i`` drives it.
 

--- a/torii/lib/stdio/serial.py
+++ b/torii/lib/stdio/serial.py
@@ -151,6 +151,11 @@ class AsyncSerialRX(Elaboratable):
 		if self._pins is not None:
 			m.submodules += FFSynchronizer(self._pins.rx.i, self.i, reset = 1)
 
+		# TODO: This has some really messed up behaviour with how the start/done bits work - this FSM
+		# needs a internals rewrite, but this can't be done till we are able to make breaking changes
+		# (prep for v1.0.0). `self.start` should be latched at the start of the frame or while busy
+		# so it can be a pulse from the driving block, rather than having to remain asserted all the way
+		# through to 'DONE'.
 		with m.FSM() as fsm:
 			with m.State('IDLE'):
 				with m.If(~self.i):


### PR DESCRIPTION
In this PR we address #40 where we had identified that the nomenclature around AsyncSerialRX was deeply misleading as to the function of two key signals.

`rdy` becomes `done`, and `ack` becomes `start` which better indicate their roles in the function of this block.