### PR TITLE
docs: add `sphinx-autodoc-typehints` support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ extensions = [
 	'sphinx_copybutton',
 	'sphinx_codeautolink',
 	'sphinx_multiversion',
+	'sphinx_autodoc_typehints',
 ]
 
 source_suffix = {
@@ -62,6 +63,11 @@ napoleon_custom_sections  = [
 ]
 
 myst_heading_anchors = 3
+
+always_use_bars_union = True
+typehints_defaults = 'braces-after'
+typehints_use_signature = True
+typehints_use_signature_return = True
 
 templates_path = [
 	'_templates',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ furo
 myst-parser
 setuptools_scm
 sphinx
+sphinx-autodoc-typehints
 sphinx-codeautolink
 sphinx-copybutton
 sphinx-inline-tabs

--- a/torii/back/cxxrtl.py
+++ b/torii/back/cxxrtl.py
@@ -47,10 +47,10 @@ def convert_fragment(
 		The Torii fragment hierarchy to lower.
 	name : str
 		The name of the root fragment module.
-		(default: 'top')
+
 	emit_src : bool
 		Emit source line attributes in the resulting CXXRTL text.
-		(default: True)
+
 	black_boxes : dict[str, str]
 		A map of CXXRTL blackboxes to use in the resulting design.
 
@@ -76,14 +76,14 @@ def convert(
 		The Elaboratable to lower into Verilog.
 	name : str
 		The name of the resulting Verilog module.
-		(default: 'top')
+
 	platform : torii.build.plat.Platform
 		The platform to use for Elaboratable evaluation.
 	ports : list[]
 		The list of ports on the top-level module.
 	emit_src : bool
 		Emit source line attributes in the final CXXRTL text.
-		(default: True)
+
 	black_boxes : dict[str, str]
 		A map of CXXRTL blackboxes to use in the resulting design.
 

--- a/torii/back/rtlil.py
+++ b/torii/back/rtlil.py
@@ -1087,10 +1087,10 @@ def convert_fragment(
 		The Torii fragment hierarchy to lower.
 	name : str
 		The name of the root fragment module.
-		(default: 'top')
+
 	emit_src : bool
 		Emit source line attributes in the resulting RTLIL text.
-		(default: True)
+
 
 	Returns
 	-------
@@ -1118,14 +1118,13 @@ def convert(
 		The Elaboratable to lower into RTLIL.
 	name : str
 		The name of the resulting RTLIL module.
-		(default: 'top')
+
 	platform : torii.build.plat.Platform
 		The platform to use for Elaboratable evaluation.
 	ports : list[]
 		The list of ports on the top-level module.
 	emit_src : bool
 		Emit source line attributes in the final RTLIL text.
-		(default: True)
 
 	Returns
 	-------

--- a/torii/back/verilog.py
+++ b/torii/back/verilog.py
@@ -55,10 +55,10 @@ def convert_fragment(
 		The Torii fragment hierarchy to lower.
 	name : str
 		The name of the root fragment module.
-		(default: 'top')
+
 	emit_src : bool
 		Emit source line attributes in the resulting Verilog text.
-		(default: True)
+
 	strip_internal_attrs : bool
 		Remove Torii-specific attributes that were emitted into the resulting Verilog text.
 
@@ -84,14 +84,14 @@ def convert(
 		The Elaboratable to lower into Verilog.
 	name : str
 		The name of the resulting Verilog module.
-		(default: 'top')
+
 	platform : torii.build.plat.Platform
 		The platform to use for Elaboratable evaluation.
 	ports : list[]
 		The list of ports on the top-level module.
 	emit_src : bool
 		Emit source line attributes in the final Verilog text.
-		(default: True)
+
 	strip_internal_attrs : bool
 		Remove Torii-specific attributes that were emitted into the resulting Verilog text.
 

--- a/torii/build/run.py
+++ b/torii/build/run.py
@@ -204,7 +204,7 @@ class BuildPlan:
 			The Torii build root.
 
 		docker_mount : str
-			The internal docker bind mount location for the build root. (default: /build)
+			The internal docker bind mount location for the build root.
 
 		docker_args : list[str]
 			Any additional arguments to pass to the docker engine.

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -846,7 +846,7 @@ class Value(metaclass = ABCMeta):
 		Parameters
 		----------
 		value : Value, in
-			Value to increment by. (default: 1)
+			Value to increment by.
 
 		Returns
 		-------
@@ -866,7 +866,7 @@ class Value(metaclass = ABCMeta):
 		Parameters
 		----------
 		value : Value, in
-			Value to decrement by. (default: 1)
+			Value to decrement by.
 
 		Returns
 		-------
@@ -1855,7 +1855,6 @@ class Sample(Value):
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Attributes
 	----------
@@ -1921,11 +1920,9 @@ def Past(expr: ValueCastT, clocks: int = 1, domain: str | None = None) -> Value:
 
 	clocks : int
 		The number of clock cycles in the past this sample should represent.
-		(default: 1)
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Returns
 	-------
@@ -1955,11 +1952,9 @@ def Stable(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Oper
 
 	clocks : int
 		The number of clock cycles in the past this sample should represent.
-		(default: 0)
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Returns
 	-------
@@ -1993,11 +1988,9 @@ def Rose(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 
 	clocks : int
 		The number of clock cycles in the past this sample should represent.
-		(default: 0)
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Returns
 	-------
@@ -2031,11 +2024,9 @@ def Fell(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 
 	clocks : int
 		The number of clock cycles in the past this sample should represent.
-		(default: 0)
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Returns
 	-------
@@ -2069,11 +2060,9 @@ def Edge(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 
 	clocks : int
 		The number of clock cycles in the past this sample should represent.
-		(default: 0)
 
 	domain : str | None
 		The domain this sample should be taken on. If ``None`` the default domain is used.
-		(default: None)
 
 	Returns
 	-------

--- a/torii/hdl/mem.py
+++ b/torii/hdl/mem.py
@@ -37,11 +37,9 @@ class Memory(Elaboratable):
 	name : str | None
 		Name hint for this memory. If ``None`` the name is inferred from the variable
 		name this ``Memory`` is assigned to.
-		(default: None)
 
 	attrs : dict | None
 		Dictionary of synthesis attributes.
-		(default: None)
 
 	Attributes
 	----------
@@ -114,11 +112,9 @@ class Memory(Elaboratable):
 		---------
 		domain : str
 			The domain this :py:class:`ReadPort` operates on.
-			(default: 'sync')
 
 		transparent : bool
 			Port transparency.
-			(default: True)
 
 		Returns
 		-------
@@ -138,11 +134,9 @@ class Memory(Elaboratable):
 		---------
 		domain : str
 			The domain this :py:class:`WritePort` operates on.
-			(default: 'sync')
 
 		granularity : int | None
 			Port granularity
-			(default: None)
 
 		Returns
 		-------
@@ -212,13 +206,11 @@ class ReadPort(Elaboratable):
 	domain : str
 		The clock domain this port operates on. If set to the ``'comb'`` domain, the port is
 		asynchronous, otherwise reads have a latency of 1 clock cycle.
-		(default: ``'sync'``)
 
 	transparent : bool
 		Port transparency. If set a read at an address that is also being written to in
 		the same clock cycle will output the new value. Otherwise, the old value will be output
 		first. This behavior only applies to ports in the same domain.
-		(default: True)
 
 	Attributes
 	----------
@@ -289,12 +281,10 @@ class WritePort(Elaboratable):
 
 	domain : str
 		The clock domain this port operates on. Writes have a latency of 1 clock cycle.
-		(default: ``'sync'``)
 
 	granularity : int | None
 		Port granularity. Write data is split evenly in ``memory.width // granularity`` chunks,
 		which can be updated independently. If ``None`` defaults to ``memory.width``.
-		(default: None)
 
 	Attributes
 	----------
@@ -377,15 +367,12 @@ class DummyPort:
 
 	domain : str
 		The domain this port is to operate on.
-		(default: 'sync')
 
 	name : str | None
 		The name of this port.
-		(default: None)
 
 	granularity : str | None
 		Port granularity if set. If ``None`` defaults to ``data_width``.
-		(default: None)
 
 	Attributes
 	----------

--- a/torii/lib/stream/simple.py
+++ b/torii/lib/stream/simple.py
@@ -31,19 +31,15 @@ class StreamInterface(Record):
 	----------
 	data_width : int
 		The width of the stream data in bits.
-		(default: 8)
 
 	valid_width : int | None
 		The width of the valid field. If ``None`` it will default to ``data_width // 8``.
-		(default: 1)
 
 	name : str | None
 		The name of this stream.
-		(default: None)
 
 	extra : Iterable[tuple[str, int]]
 		Any extra or ancillary fields to graft on to the stream.
-		(default: [])
 
 	Attributes
 	----------
@@ -125,7 +121,6 @@ class StreamInterface(Record):
 
 		omit : set[str]
 			A set of additional stream fields to exclude from the tap connection.
-			(default: {})
 		'''
 
 		rhs = ('valid', 'first', 'last', 'data', *self._extra_fields)
@@ -173,7 +168,6 @@ class StreamInterface(Record):
 
 		omit : set[str]
 			A set of additional stream fields to exclude from the tap connection.
-			(default: {})
 		'''
 		return stream.attach(self, omit = omit)
 
@@ -199,11 +193,9 @@ class StreamInterface(Record):
 		tap_ready : bool
 			By default the ``ready`` signal is excluded from the tap, passing ``True`` here will also
 			connect that signal.
-			(default: False)
 
 		omit : set[str]
 			A set of additional stream fields to exclude from the tap connection.
-			(default: {})
 		'''
 
 		tap = self.stream_eq(stream, {'ready', *omit})
@@ -227,12 +219,10 @@ class StreamArbiter(Generic[T], Elaboratable):
 	----------
 	domain : str
 		The domain in which the arbiter should operate.
-		(default: sync)
 
 	stream_type : type
 		The type of stream to create, must be either :py:class:`StreamInterface <torii.lib.stream.StreamInterface>`
 		or a subtype there of.
-		(default: torii.lib.stream.StreamInterface)
 
 	Attributes
 	----------
@@ -263,7 +253,6 @@ class StreamArbiter(Generic[T], Elaboratable):
 
 		priority : int
 			The stream priority.
-			(default: -1)
 		'''
 		if priority > 0:
 			self._sources.append(stream)

--- a/torii/tools/cxx.py
+++ b/torii/tools/cxx.py
@@ -71,22 +71,14 @@ def compile_cxx(
 	include_paths : Iterable[str | Path] | None
 		A list of extra include paths to pass to the compiler.
 
-		default: None
-
 	library_paths : Iterable[str | Path] | None
 		A list of extra library search paths to pass to the compiler.
-
-		default: None
 
 	defines : dict[str, str] | None
 		A collection of preprocessor definitions to pass to the compiler.
 
-		default: None
-
 	output_type : ObjectType
 		The type of object to build.
-
-		default: ObjectType.SHLIB
 
 	source_listings : dict[str, str] | None
 		A collection of ``filename: source listing`` pairs to include in the build.
@@ -96,37 +88,23 @@ def compile_cxx(
 		of the file via the ``source_files`` parameter rather than reading the file into memory
 		to pass here.
 
-		default: None
-
 	extra_libs : Iterable[str | Path] | None
 		A list of extra libraries to link against.
-
-		default: None
 
 	extra_objs : Iterable[str | Path] | None
 		A list of extra object files to link with.
 
-		default: None
-
 	extra_cxx_opts : Iterable[str] | None
 		A list of extra options to pass to the compiler.
-
-		default: None
 
 	extra_ld_opts : Iterable[str] | None
 		A list of extra options to pass to the linker.
 
-		default: None
-
 	verbose : bool
 		Enable verbose compiler output.
 
-		default: False
-
 	debug : bool
 		Build in debug mode.
-
-		default: False
 
 	Returns
 	-------

--- a/torii/util/tracer.py
+++ b/torii/util/tracer.py
@@ -27,11 +27,9 @@ def get_var_name(depth: int = 2, default: str | object = _raise_exception) -> st
 	----------
 	depth : int
 		The number of stack frames above us to look.
-		(default: 2)
 
 	default : str | object
 		The default name of the variable if it's not found.
-		(default: _raise_exception)
 
 	Important
 	---------
@@ -113,7 +111,6 @@ def get_src_loc(src_loc_at: int = 0) -> SrcLoc:
 	----------
 	src_loc_at : int
 		The frame above this call in which to get the file and line number from.
-		(default: 0)
 
 	Important
 	---------

--- a/torii/warnings.py
+++ b/torii/warnings.py
@@ -88,8 +88,6 @@ def _get_console(output_stream: TextIO | None) -> Console:
 
 		If it is ``None`` or :py:class:`sys.stdout` then the default Rich
 		:py:class:`Console <rich.console.Console>` is used.
-
-		default: None
 	'''
 	if output_stream is None or output_stream == stdout:
 		return get_console()
@@ -205,15 +203,11 @@ def _warning_handler( # :nocov:
 
 		If ``None`` it defaults to :py:class:`sys.stdout`
 
-		default: None
-
 	line : str | None
 		The text of the line the warning was raised on.
 
 		If ``None`` this is collected with the :py:mod:`linecache` module,
 		using the provided ``filename`` and ``lineno``.
-
-		default: None
 	'''
 
 	# Get the output console to write to
@@ -281,8 +275,6 @@ def install_handler(*, catch_all: bool = False) -> None:
 	----------
 	catch_all : bool
 		Flush the Python warnings filters so all warnings are asserted.
-
-		default: False
 	'''
 
 	# If the environment is telling us to not handle the warnings don't,


### PR DESCRIPTION
This PR add the [`sphinx-autodoc-typehints`] extension which allows for better rich-typing in the generated documentation.

It also does things such as automatically append the value defaults into the generated docs so we no longer need to spciefy them inline.