### PR TITLE
typing: Ensure all `__init__`'s return `None`

### DIFF
--- a/docs/_code/up_counter.py
+++ b/docs/_code/up_counter.py
@@ -17,7 +17,7 @@ class UpCounter(Elaboratable):
     ovf : Signal, out
         ``ovf`` is asserted when the counter reaches its limit.
     '''
-    def __init__(self, limit: int):
+    def __init__(self, limit: int) -> None:
         self.limit = limit
 
         # Ports

--- a/examples/basic/alu.py
+++ b/examples/basic/alu.py
@@ -4,7 +4,7 @@ from torii.hdl  import Cat, Elaboratable, Module, Signal
 from torii.back import verilog
 
 class ALU(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.sel = Signal(2)
 		self.a   = Signal(width)
 		self.b   = Signal(width)

--- a/examples/basic/alu_hier.py
+++ b/examples/basic/alu_hier.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Module, Signal
 from torii.back import verilog
 
 class Adder(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.a   = Signal(width)
 		self.b   = Signal(width)
 		self.o   = Signal(width)
@@ -15,7 +15,7 @@ class Adder(Elaboratable):
 		return m
 
 class Subtractor(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.a   = Signal(width)
 		self.b   = Signal(width)
 		self.o   = Signal(width)
@@ -26,7 +26,7 @@ class Subtractor(Elaboratable):
 		return m
 
 class ALU(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.op  = Signal()
 		self.a   = Signal(width)
 		self.b   = Signal(width)

--- a/examples/basic/arst.py
+++ b/examples/basic/arst.py
@@ -4,7 +4,7 @@ from torii.hdl  import ClockDomain, Elaboratable, Module, Signal
 from torii.back import verilog
 
 class ClockDivisor(Elaboratable):
-	def __init__(self, factor: int):
+	def __init__(self, factor: int) -> None:
 		self.v = Signal(factor)
 		self.o = Signal()
 

--- a/examples/basic/ctr.py
+++ b/examples/basic/ctr.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Module, Signal
 from torii.back import verilog
 
 class Counter(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.v = Signal(width, reset = 2**width-1)
 		self.o = Signal()
 

--- a/examples/basic/ctr_en.py
+++ b/examples/basic/ctr_en.py
@@ -5,7 +5,7 @@ from torii.back import verilog
 from torii.sim  import Simulator
 
 class Counter(Elaboratable):
-	def __init__(self, width: int):
+	def __init__(self, width: int) -> None:
 		self.v = Signal(width, reset = 2**width-1)
 		self.o = Signal()
 		self.en = Signal()

--- a/examples/basic/fsm.py
+++ b/examples/basic/fsm.py
@@ -4,7 +4,7 @@ from torii.hdl  import Cat, Elaboratable, Module, Signal
 from torii.back import verilog
 
 class UARTReceiver(Elaboratable):
-	def __init__(self, divisor: int):
+	def __init__(self, divisor: int) -> None:
 		self.divisor = divisor
 
 		self.i    = Signal()

--- a/examples/basic/gpio.py
+++ b/examples/basic/gpio.py
@@ -4,7 +4,7 @@ from torii.hdl  import Array, Elaboratable, Module, Record, Signal
 from torii.back import verilog
 
 class GPIO(Elaboratable):
-	def __init__(self, pins, bus):
+	def __init__(self, pins, bus) -> None:
 		self.pins = pins
 		self.bus  = bus
 

--- a/examples/basic/inst.py
+++ b/examples/basic/inst.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Instance, Module, Signal
 from torii.back import verilog
 
 class System(Elaboratable):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.adr   = Signal(16)
 		self.dat_r = Signal(8)
 		self.dat_w = Signal(8)

--- a/examples/basic/mem.py
+++ b/examples/basic/mem.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Memory, Module, Signal
 from torii.back import verilog
 
 class RegisterFile(Elaboratable):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.adr   = Signal(4)
 		self.dat_r = Signal(8)
 		self.dat_w = Signal(8)

--- a/examples/basic/pmux.py
+++ b/examples/basic/pmux.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Module, Signal
 from torii.back import verilog
 
 class ParMux(Elaboratable):
-	def __init__(self, width):
+	def __init__(self, width) -> None:
 		self.s = Signal(3)
 		self.a = Signal(width)
 		self.b = Signal(width)

--- a/examples/basic/sel.py
+++ b/examples/basic/sel.py
@@ -4,7 +4,7 @@ from torii.hdl  import Elaboratable, Module, Record, Signal
 from torii.back import verilog
 
 class FlatGPIO(Elaboratable):
-	def __init__(self, pins, bus):
+	def __init__(self, pins, bus) -> None:
 		self.pins = pins
 		self.bus  = bus
 

--- a/examples/basic/uart.py
+++ b/examples/basic/uart.py
@@ -10,7 +10,7 @@ class UART(Elaboratable):
 		Set to ``round(clk-rate / baud-rate)``.
 		E.g. ``12e6 / 115200`` = ``104``.
 	'''
-	def __init__(self, divisor, data_bits = 8):
+	def __init__(self, divisor, data_bits = 8) -> None:
 		assert divisor >= 4
 
 		self.data_bits = data_bits

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -184,7 +184,7 @@ class ShapeTestCase(ToriiTestSuiteCase):
 			Shape.cast('foo')
 
 class MockShapeCastable(ShapeCastable):
-	def __init__(self, dest):
+	def __init__(self, dest) -> None:
 		self.dest = dest
 
 	def as_shape(self):
@@ -205,7 +205,7 @@ class ShapeCastableTestCase(ToriiTestSuiteCase):
 
 		with self.assertRaisesRegex(TypeError, err_msg_regex):
 			class MockShapeCastableNoOverride(ShapeCastable):
-				def __init__(self):
+				def __init__(self) -> None:
 					pass # :nocov:
 
 			_ = MockShapeCastableNoOverride()
@@ -634,7 +634,7 @@ class ConstTestCase(ToriiTestSuiteCase):
 
 	def test_shape_castable(self):
 		class MockConstValue:
-			def __init__(self, value):
+			def __init__(self, value) -> None:
 				self.value = value
 
 		class MockConstShape(ShapeCastable):
@@ -1519,7 +1519,7 @@ class ResetSignalTestCase(ToriiTestSuiteCase):
 			ResetSignal('comb')
 
 class MockValueCastable(ValueCastable):
-	def __init__(self, dest):
+	def __init__(self, dest) -> None:
 		self.dest = dest
 
 	def shape(self):
@@ -1530,7 +1530,7 @@ class MockValueCastable(ValueCastable):
 		return self.dest
 
 class MockValueCastableChanges(ValueCastable):
-	def __init__(self, width = 0):
+	def __init__(self, width = 0) -> None:
 		self.width = width
 
 	def shape(self):
@@ -1541,7 +1541,7 @@ class MockValueCastableChanges(ValueCastable):
 		return Signal(self.width)
 
 class MockValueCastableCustomGetattr(ValueCastable):
-	def __init__(self):
+	def __init__(self) -> None:
 		pass
 
 	def shape(self):
@@ -1562,7 +1562,7 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 			r'decorate the `as_value` method with the `ValueCastable.lowermethod` decorator$'
 		):
 			class MockValueCastableNotDecorated(ValueCastable):
-				def __init__(self):
+				def __init__(self) -> None:
 					pass # :nocov:
 
 				def shape(self):
@@ -1578,7 +1578,7 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 			r'override the `as_value` method$'
 		):
 			class MockValueCastableNoOverrideAsValue(ValueCastable):
-				def __init__(self):
+				def __init__(self) -> None:
 					pass # :nocov:
 
 		with self.assertRaisesRegex(
@@ -1587,7 +1587,7 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 			r'override the `shape` method$'
 		):
 			class MockValueCastableNoOverrideShape(ValueCastable):
-				def __init__(self):
+				def __init__(self) -> None:
 					pass # :nocov:
 
 				def as_value(self):
@@ -1668,7 +1668,7 @@ class ValueLikeTestCase(ToriiTestSuiteCase):
 		self.assertFalse(isinstance(EnumD.A, ValueLike))
 
 class SampleDUT(Elaboratable):
-	def __init__(self, v: Signal, s: Signal, clocks: int, mode: str | None = None):
+	def __init__(self, v: Signal, s: Signal, clocks: int, mode: str | None = None) -> None:
 		self.v = v
 		self.s = s
 

--- a/tests/hdl/test_xfrm.py
+++ b/tests/hdl/test_xfrm.py
@@ -579,7 +579,7 @@ class EnableInserterTestCase(ToriiTestSuiteCase):
 		''')
 
 class _MockElaboratable(Elaboratable):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.s1 = Signal()
 
 	def elaborate(self, platform):

--- a/tests/lib/bus/test_bus.py
+++ b/tests/lib/bus/test_bus.py
@@ -291,7 +291,7 @@ class DecoderSimulationTestCase(ToriiTestSuiteCase):
 
 	def test_addr_translate(self):
 		class AddressLoopback(Elaboratable):
-			def __init__(self, **kwargs):
+			def __init__(self, **kwargs) -> None:
 				self.bus = Interface(**kwargs)
 
 			def elaborate(self, platform):

--- a/tests/lib/coding/test_gray.py
+++ b/tests/lib/coding/test_gray.py
@@ -9,7 +9,7 @@ from torii.lib.formal      import Assert, Assume
 from ...utils              import ToriiTestSuiteCase
 
 class ReversibleSpec(Elaboratable):
-	def __init__(self, encoder_cls, decoder_cls, args):
+	def __init__(self, encoder_cls, decoder_cls, args) -> None:
 		self.encoder_cls = encoder_cls
 		self.decoder_cls = decoder_cls
 		self.coder_args  = args
@@ -25,7 +25,7 @@ class ReversibleSpec(Elaboratable):
 		return m
 
 class HammingDistanceSpec(Elaboratable):
-	def __init__(self, distance, encoder_cls, args):
+	def __init__(self, distance, encoder_cls, args) -> None:
 		self.distance    = distance
 		self.encoder_cls = encoder_cls
 		self.coder_args  = args

--- a/tests/lib/soc/csr/test_wishbone.py
+++ b/tests/lib/soc/csr/test_wishbone.py
@@ -11,7 +11,7 @@ from torii.sim                  import Simulator
 from ....utils                  import ToriiTestSuiteCase
 
 class MockRegister(Elaboratable):
-	def __init__(self, width, name):
+	def __init__(self, width, name) -> None:
 		self.element = csr.Element(width, 'rw', name = name)
 		self.r_count = Signal(8)
 		self.w_count = Signal(8)

--- a/tests/lib/test_fifo.py
+++ b/tests/lib/test_fifo.py
@@ -77,7 +77,7 @@ class FIFOModel(Elaboratable, FIFOInterface):
 	'''
 	Non-synthesizable first-in first-out queue, implemented naively as a chain of registers.
 	'''
-	def __init__(self, *, width, depth, fwft, r_domain, w_domain):
+	def __init__(self, *, width, depth, fwft, r_domain, w_domain) -> None:
 		super().__init__(width = width, depth = depth, fwft = fwft)
 
 		self.r_domain = r_domain
@@ -134,7 +134,7 @@ class FIFOModelEquivalenceSpec(Elaboratable):
 	signals, the behavior of the implementation under test exactly matches the ideal model,
 	except for behavior not defined by the model.
 	'''
-	def __init__(self, fifo, r_domain, w_domain):
+	def __init__(self, fifo, r_domain, w_domain) -> None:
 		self.fifo = fifo
 
 		self.r_domain = r_domain
@@ -179,7 +179,7 @@ class FIFOContractSpec(Elaboratable):
 	consecutively, they must be read out consecutively at some later point, no matter all other
 	circumstances, with the exception of reset.
 	'''
-	def __init__(self, fifo, *, r_domain, w_domain, bound):
+	def __init__(self, fifo, *, r_domain, w_domain, bound) -> None:
 		self.fifo     = fifo
 		self.r_domain = r_domain
 		self.w_domain = w_domain

--- a/tests/sim/test_sim.py
+++ b/tests/sim/test_sim.py
@@ -1549,7 +1549,7 @@ class SimulatorEngineTestCase(ToriiTestSuiteCase):
 		from torii.sim._base import BaseEngine
 
 		class DummyEngine(BaseEngine):
-			def __init__(self, fragment):
+			def __init__(self, fragment) -> None:
 				pass
 
 		_ = Simulator(Module(), engine = DummyEngine)

--- a/tests/util/test_decorators.py
+++ b/tests/util/test_decorators.py
@@ -9,7 +9,7 @@ class DecoratorsTestCase(ToriiTestCase):
 
 		@decorators.final
 		class Foo:
-			def __init__(self):
+			def __init__(self) -> None:
 				pass # :nocov:
 
 		with self.assertRaisesRegex(

--- a/torii/back/rtlil.py
+++ b/torii/back/rtlil.py
@@ -233,7 +233,7 @@ class _ProcessBuilder(_AttrBuilder, _BufferedBuilder):
 		return _CaseBuilder(self, indent = 2)
 
 class _CaseBuilder(_ProxiedBuilder):
-	def __init__(self, rtlil, indent: int):
+	def __init__(self, rtlil, indent: int) -> None:
 		self.rtlil  = rtlil
 		self.indent = indent
 
@@ -380,7 +380,7 @@ class _ValueCompilerState:
 			del self.expansions[value]
 
 class _ValueCompiler(xfrm.ValueVisitor):
-	def __init__(self, state):
+	def __init__(self, state) -> None:
 		self.s = state
 
 	def on_unknown(self, value):
@@ -686,7 +686,7 @@ class _LHSValueCompiler(_ValueCompiler):
 			)
 
 class _StatementCompiler(xfrm.StatementVisitor):
-	def __init__(self, state, rhs_compiler, lhs_compiler):
+	def __init__(self, state, rhs_compiler, lhs_compiler) -> None:
 		self.state        = state
 		self.rhs_compiler = rhs_compiler
 		self.lhs_compiler = lhs_compiler

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2293,7 +2293,7 @@ class _MappedKeyCollection(Generic[IntKey, Key], metaclass = ABCMeta):
 		pass # :nocov:
 
 class _MappedKeyDict(MutableMapping[Key | None, Val], _MappedKeyCollection[IntKey, Key]):
-	def __init__(self, pairs: tuple[tuple[Key, Val], ...] = ()):
+	def __init__(self, pairs: tuple[tuple[Key, Val], ...] = ()) -> None:
 		self._storage = OrderedDict[IntKey | None, Val]()
 		for key, value in pairs:
 			self[key] = value

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -39,12 +39,12 @@ class _ModuleBuilderProxy:
 	_builder: Module
 	_depth: int
 
-	def __init__(self, builder: Module, depth: int):
+	def __init__(self, builder: Module, depth: int) -> None:
 		object.__setattr__(self, '_builder', builder)
 		object.__setattr__(self, '_depth', depth)
 
 class _ModuleBuilderDomain(_ModuleBuilderProxy):
-	def __init__(self, builder: Module, depth: int, domain: str | None):
+	def __init__(self, builder: Module, depth: int, domain: str | None) -> None:
 		super().__init__(builder, depth)
 		self._domain = domain
 
@@ -79,7 +79,7 @@ class _ModuleBuilderDomains(_ModuleBuilderProxy):
 		return self.__setattr__(name, value)
 
 class _ModuleBuilderRoot:
-	def __init__(self, builder: Module, depth: int):
+	def __init__(self, builder: Module, depth: int) -> None:
 		self._builder = builder
 		self.domain = self.d = _ModuleBuilderDomains(builder, depth)
 
@@ -91,7 +91,7 @@ class _ModuleBuilderRoot:
 class _ModuleBuilderSubmodules:
 	_builder: Module
 
-	def __init__(self, builder: Module):
+	def __init__(self, builder: Module) -> None:
 		object.__setattr__(self, '_builder', builder)
 
 	def __iadd__(self, modules):
@@ -114,7 +114,7 @@ class _ModuleBuilderSubmodules:
 class _ModuleBuilderDomainSet:
 	_builder: Module
 
-	def __init__(self, builder: Module):
+	def __init__(self, builder: Module) -> None:
 		object.__setattr__(self, '_builder', builder)
 
 	def __iadd__(self, domains: Iterable):
@@ -136,7 +136,7 @@ Params = ParamSpec('Params')
 # It's not particularly clean to depend on an internal interface, but, unfortunately, __bool__
 # must be defined on a class to be called during implicit conversion.
 class _GuardedContextManager(_GeneratorContextManager):
-	def __init__(self, keyword: str, func: Callable[Params, Generator[Any, Any, None]], args: tuple, kwds: dict):
+	def __init__(self, keyword: str, func: Callable[Params, Generator[Any, Any, None]], args: tuple, kwds: dict) -> None:
 		self.keyword = keyword
 		return super().__init__(func, args, kwds)
 
@@ -152,7 +152,7 @@ def _guardedcontextmanager(keyword: str):
 	return decorator
 
 class FSM:
-	def __init__(self, state, encoding, decoding):
+	def __init__(self, state, encoding, decoding) -> None:
 		self.state    = state
 		self.encoding = encoding
 		self.decoding = decoding
@@ -196,7 +196,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			'and return a `Module` from the `elaborate(self, platform)` method'
 		)
 
-	def __init__(self):
+	def __init__(self) -> None:
 		super().__init__(builder = self, depth = 0)
 		self.submodules    = _ModuleBuilderSubmodules(self)
 		self.domains       = _ModuleBuilderDomainSet(self)

--- a/torii/hdl/ir.py
+++ b/torii/hdl/ir.py
@@ -80,7 +80,7 @@ class Fragment:
 					lineno = code.co_firstlineno)
 			obj = new_obj
 
-	def __init__(self):
+	def __init__(self) -> None:
 		self.ports = SignalDict()
 		self.drivers = OrderedDict[str | None, SignalSet]()
 		self.statements: list[Statement] = []
@@ -700,7 +700,7 @@ class Instance(Fragment):
 	def __init__(
 		self, type: str, *args: InstanceArgsT, src_loc: SrcLoc | None = None, src_loc_at: int = 0,
 		**kwargs: ValueCastT | str
-	):
+	) -> None:
 		super().__init__()
 
 		self.type        = type

--- a/torii/hdl/mem.py
+++ b/torii/hdl/mem.py
@@ -238,7 +238,7 @@ class ReadPort(Elaboratable):
 
 	'''
 
-	def __init__(self, memory: Memory, *, domain: str = 'sync', transparent: bool = True, src_loc_at: int = 0):
+	def __init__(self, memory: Memory, *, domain: str = 'sync', transparent: bool = True, src_loc_at: int = 0) -> None:
 		if domain == 'comb' and not transparent:
 			raise ValueError('Read port cannot be simultaneously asynchronous and non-transparent')
 
@@ -314,7 +314,9 @@ class WritePort(Elaboratable):
 
 	'''
 
-	def __init__(self, memory: Memory, *, domain: str = 'sync', granularity: int | None = None, src_loc_at: int = 0):
+	def __init__(
+		self, memory: Memory, *, domain: str = 'sync', granularity: int | None = None, src_loc_at: int = 0
+	) -> None:
 		if granularity is None:
 			granularity = memory.width
 		if not isinstance(granularity, int) or granularity < 0:
@@ -392,7 +394,7 @@ class DummyPort:
 	def __init__(
 		self, *, data_width: int, addr_width: int, domain: str = 'sync', name: str | None = None,
 		granularity: int | None = None
-	):
+	) -> None:
 		self.domain = domain
 
 		if granularity is None:
@@ -405,7 +407,7 @@ class DummyPort:
 		self.en   = Signal(data_width // granularity, name = f'{name}_en', src_loc_at = 1)
 
 class MemoryInstance(Fragment):
-	def __init__(self, memory: Memory, read_ports: list[ReadPort], write_ports: list[WritePort]):
+	def __init__(self, memory: Memory, read_ports: list[ReadPort], write_ports: list[WritePort]) -> None:
 		super().__init__()
 		self.memory      = memory
 		self.read_ports  = read_ports

--- a/torii/hdl/xfrm.py
+++ b/torii/hdl/xfrm.py
@@ -314,7 +314,7 @@ class FragmentTransformer:
 			raise AttributeError(f'Object {value!r} cannot be elaborated')
 
 class TransformedElaboratable(Elaboratable):
-	def __init__(self, elaboratable, *, src_loc_at = 0):
+	def __init__(self, elaboratable, *, src_loc_at = 0) -> None:
 		if not hasattr(elaboratable, 'elaborate'):
 			raise TypeError(f'Unable to elaborate object of type \'{type(elaboratable)}\' which has no \'elaborate\' method')
 
@@ -333,7 +333,7 @@ class TransformedElaboratable(Elaboratable):
 		return fragment
 
 class DomainCollector(ValueVisitor, StatementVisitor):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.used_domains = set()
 		self.defined_domains = set()
 		self._local_domains = set()
@@ -517,7 +517,7 @@ class DomainRenamer(FragmentTransformer, ValueTransformer, StatementTransformer)
 				port.domain = self.domain_map[port.domain]
 
 class DomainLowerer(FragmentTransformer, ValueTransformer, StatementTransformer):
-	def __init__(self, domains = None):
+	def __init__(self, domains = None) -> None:
 		self.domains = domains
 
 	def _resolve(self, domain, context):
@@ -565,7 +565,7 @@ class DomainLowerer(FragmentTransformer, ValueTransformer, StatementTransformer)
 		return new_fragment
 
 class SampleDomainInjector(ValueTransformer, StatementTransformer):
-	def __init__(self, domain):
+	def __init__(self, domain) -> None:
 		self.domain = domain
 
 	def on_Sample(self, value):
@@ -577,7 +577,7 @@ class SampleDomainInjector(ValueTransformer, StatementTransformer):
 		return self.on_statement(stmts)
 
 class SampleLowerer(FragmentTransformer, ValueTransformer, StatementTransformer):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.initial = None
 		self.sample_cache = None
 		self.sample_stmts = None
@@ -654,7 +654,7 @@ class SwitchCleaner(StatementVisitor):
 		return _StatementList(stmt for stmt in stmts if stmt is not None)
 
 class LHSGroupAnalyzer(StatementVisitor):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.signals = SignalDict()
 		self.unions  = OrderedDict()
 
@@ -707,7 +707,7 @@ class LHSGroupAnalyzer(StatementVisitor):
 		return self.groups()
 
 class LHSGroupFilter(SwitchCleaner):
-	def __init__(self, signals):
+	def __init__(self, signals) -> None:
 		self.signals = signals
 
 	def on_Assign(self, stmt):
@@ -725,7 +725,7 @@ class LHSGroupFilter(SwitchCleaner):
 			return stmt
 
 class _ControlInserter(FragmentTransformer):
-	def __init__(self, controls):
+	def __init__(self, controls) -> None:
 		self.src_loc = None
 		if isinstance(controls, Value):
 			controls = { 'sync': controls }

--- a/torii/lib/fifo.py
+++ b/torii/lib/fifo.py
@@ -247,7 +247,7 @@ class SyncFIFOBuffered(Elaboratable, FIFOInterface):
 		),
 	)
 
-	def __init__(self, *, width: int, depth: int):
+	def __init__(self, *, width: int, depth: int) -> None:
 		super().__init__(width = width, depth = depth)
 
 		self.level = Signal(range(depth + 1))

--- a/torii/lib/soc/csr/bus.py
+++ b/torii/lib/soc/csr/bus.py
@@ -210,7 +210,7 @@ class Multiplexer(Elaboratable):
 			w_en: Signal
 
 			'''The interface between a CSR multiplexer and a shadow register chunk.'''
-			def __init__(self, shadow: Multiplexer._Shadow, offset: int, elements: list[range]):
+			def __init__(self, shadow: Multiplexer._Shadow, offset: int, elements: list[range]) -> None:
 				self.name = f'{shadow.name}__{offset}'
 				self.data = Signal(shadow.granularity, name = f'{self.name}__data')
 				self.r_en = Signal(name = f'{self.name}__r_en')

--- a/torii/platform/vendor/gowin.py
+++ b/torii/platform/vendor/gowin.py
@@ -320,7 +320,7 @@ class GowinPlatform(TemplatedPlatform):
 		'''
 	]
 
-	def __init__(self, *, toolchain = 'Apicula'):
+	def __init__(self, *, toolchain = 'Apicula') -> None:
 		super().__init__()
 
 		if toolchain not in ('Apicula', 'Gowin'):

--- a/torii/sim/_base.py
+++ b/torii/sim/_base.py
@@ -57,7 +57,7 @@ class BaseSimulation:
 		raise NotImplementedError
 
 class BaseEngine:
-	def __init__(self, fragment: Fragment):
+	def __init__(self, fragment: Fragment) -> None:
 		pass
 
 	def add_coroutine_process(self, process, *, default_cmd):

--- a/torii/sim/pysim/__init__.py
+++ b/torii/sim/pysim/__init__.py
@@ -29,7 +29,7 @@ class _VCDWriter:
 	def __init__(
 		self, fragment: Fragment, *, vcd_file: IO | str | None, gtkw_file: IO | str | None = None,
 		traces: Iterable[Signal] = ()
-	):
+	) -> None:
 
 		self._close_vcd = False
 		self._close_gtkw = False
@@ -157,7 +157,7 @@ class _VCDWriter:
 			self.gtkw_file.close()
 
 class _Timeline:
-	def __init__(self):
+	def __init__(self) -> None:
 		self.now = 0
 		self.deadlines = dict()
 
@@ -209,7 +209,7 @@ class _Timeline:
 class _PySignalState(BaseSignalState):
 	__slots__ = ('signal', 'curr', 'next', 'waiters', 'pending')
 
-	def __init__(self, signal, pending):
+	def __init__(self, signal, pending) -> None:
 		self.signal = signal
 		self.pending = pending
 		self.waiters = dict()
@@ -233,7 +233,7 @@ class _PySignalState(BaseSignalState):
 		return awoken_any
 
 class _PySimulation(BaseSimulation):
-	def __init__(self):
+	def __init__(self) -> None:
 		self.timeline = _Timeline()
 		self.signals  = SignalDict()
 		self.slots    = []
@@ -280,7 +280,7 @@ class _PySimulation(BaseSimulation):
 		return converged
 
 class PySimEngine(BaseEngine):
-	def __init__(self, fragment):
+	def __init__(self, fragment) -> None:
 		self._state = _PySimulation()
 		self._timeline = self._state.timeline
 

--- a/torii/sim/pysim/_pyclock.py
+++ b/torii/sim/pysim/_pyclock.py
@@ -7,7 +7,7 @@ __all__ = (
 )
 
 class PyClockProcess(BaseProcess):
-	def __init__(self, state, signal, *, phase, period):
+	def __init__(self, state, signal, *, phase, period) -> None:
 		if len(signal) != 1:
 			raise TypeError(f'Clock signal must be exactly 1-wide, not {len(signal)}')
 

--- a/torii/sim/pysim/_pycoro.py
+++ b/torii/sim/pysim/_pycoro.py
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 class PyCoroProcess(BaseProcess):
-	def __init__(self, state, domains, constructor, *, default_cmd = None):
+	def __init__(self, state, domains, constructor, *, default_cmd = None) -> None:
 		self.state = state
 		self.domains = domains
 		self.constructor = constructor

--- a/torii/sim/pysim/_pyrtl.py
+++ b/torii/sim/pysim/_pyrtl.py
@@ -18,7 +18,7 @@ _USE_PATTERN_MATCHING = (version_info >= (3, 10))
 class PyRTLProcess(BaseProcess):
 	__slots__ = ('is_comb', 'runnable', 'passive', 'run')
 
-	def __init__(self, *, is_comb):
+	def __init__(self, *, is_comb) -> None:
 		self.is_comb  = is_comb
 
 		self.reset()
@@ -28,7 +28,7 @@ class PyRTLProcess(BaseProcess):
 		self.passive  = True
 
 class _PythonEmitter:
-	def __init__(self):
+	def __init__(self) -> None:
 		self._buffer = []
 		self._suffix = 0
 		self._level  = 0
@@ -60,7 +60,7 @@ class _PythonEmitter:
 		return name
 
 class _Compiler:
-	def __init__(self, state, emitter):
+	def __init__(self, state, emitter) -> None:
 		self.state = state
 		self.emitter = emitter
 
@@ -105,7 +105,7 @@ class _ValueCompiler(ValueVisitor, _Compiler):
 		raise NotImplementedError # :nocov:
 
 class _RHSValueCompiler(_ValueCompiler):
-	def __init__(self, state, emitter, *, mode, inputs = None):
+	def __init__(self, state, emitter, *, mode, inputs = None) -> None:
 		super().__init__(state, emitter)
 		if mode not in ('curr', 'next'):
 			raise ValueError(f'Expected mode to be \'curr\', or \'next\', not \'{mode!r}\'')
@@ -252,7 +252,7 @@ class _RHSValueCompiler(_ValueCompiler):
 		return emitter.flush()
 
 class _LHSValueCompiler(_ValueCompiler):
-	def __init__(self, state, emitter, *, rhs, outputs = None):
+	def __init__(self, state, emitter, *, rhs, outputs = None) -> None:
 		super().__init__(state, emitter)
 		# `rrhs` is used to translate rvalues that are syntactically a part of an lvalue, e.g.
 		# the offset of a Part.
@@ -347,7 +347,7 @@ class _LHSValueCompiler(_ValueCompiler):
 		return gen
 
 class _StatementCompiler(StatementVisitor, _Compiler):
-	def __init__(self, state, emitter, *, inputs = None, outputs = None):
+	def __init__(self, state, emitter, *, inputs = None, outputs = None) -> None:
 		super().__init__(state, emitter)
 		self.rhs = _RHSValueCompiler(state, emitter, mode = 'curr', inputs = inputs)
 		self.lhs = _LHSValueCompiler(state, emitter, rhs = self.rhs, outputs = outputs)
@@ -404,7 +404,7 @@ class _StatementCompiler(StatementVisitor, _Compiler):
 		return emitter.flush()
 
 class _FragmentCompiler:
-	def __init__(self, state):
+	def __init__(self, state) -> None:
 		self.state = state
 
 	def __call__(self, fragment):


### PR DESCRIPTION
This PR add the return annotations for all the `__init__` methods that were missing them,