### PR TITLE
Feature: LFSR Generator Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Unreleased template stuff
 - New enhanced diagnostics for Torii designs.
 - New `has_submodule` call on `Module`s to check if the current module has a named submodule.
 - Added `Value.shl`/`Value.shr`/`Value.rol`/`Value.ror` operations for in-place rotates/shifts of Values/Signals.
+- New `torii.lib.lfsr` module for Galois and Fibonacci Linear-feedback shift registers (LFSRs).
 
 ### Changed
 

--- a/tests/lib/test_lfsr.py
+++ b/tests/lib/test_lfsr.py
@@ -1,73 +1,92 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.lib.lfsr import LFSR, LFSRDir, LFSRKind
-from torii.test     import ToriiTestCase
+from torii.hdl         import Const, Elaboratable, Module
+from torii.lib.lfsr    import LFSR, LFSRDir, LFSRKind
+from torii.test        import ToriiTestCase
+from torii.util.tracer import get_var_name
 
-from ..utils        import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
-class LFSRTestCase(ToriiTestSuiteCase):
-	dut: LFSR | type[LFSR] = LFSR
-	dut_args = {
-		'polynomial': (1 << 7) | (1 << 6) | (1 << 0), # x^7 + x^6 + x^0
-		'state_width': 7,
-		'io_width': 1,
-		'seed': 0x2,
-		'kind': LFSRKind.Galois,
-		'direction': LFSRDir.LSb,
-	}
+class LFSR_DUT(Elaboratable):
+	def __init__(self, loopback: bool = False, input_const: Const | None = None, **lfsr_args) -> None:
+		self.lfsr_args = lfsr_args
+		self.loopback  = loopback
+		self.in_const  = input_const
 
-	@ToriiTestCase.simulation
-	@ToriiTestCase.sync_domain(domain = 'sync')
-	def test_lfsr(self):
-		for _ in range(4096):
-			yield
-			yield
+	def elaborate(self, platform) -> Module:
+		m = Module()
+
+		m.submodules.lfsr = lfsr = LFSR(**self.lfsr_args)
+
+		self.state = lfsr.state
+
+		if self.loopback:
+			m.d.comb += [
+				lfsr.input.eq(lfsr.output)
+			]
+		elif self.in_const is not None:
+			m.d.comb += [
+				lfsr.input.eq(self.in_const)
+			]
+
+		return m
 
 
-class LFSR2TestCase(ToriiTestSuiteCase):
-	dut: LFSR | type[LFSR] = LFSR
-	dut_args = {
-		'polynomial': (1 << 16) | (1 << 14) | (1 << 13) | ( 1 << 11) | (1 << 0), # x^16 + x^14 + x^13 + x^11 + x^0
-		'state_width': 16,
-		'io_width': 1,
-		'seed': 0xACE1,
-		'kind': LFSRKind.Galois,
-		'direction': LFSRDir.LSb,
-	}
+def make_lfsr_test(
+	*, polynomial: int, state_width: int, io_width: int, seed: int, kind: LFSRKind, direction: LFSRDir,
+	feed_forward: bool, loopback: bool = False, input_const: Const | None = None, refgen = None
+) -> type[ToriiTestSuiteCase]:
+	class _LFSRTestCase(ToriiTestSuiteCase):
+		dut: LFSR_DUT | type[LFSR_DUT] = LFSR_DUT
+		dut_args = {
+			'loopback': loopback,
+			'input_const': input_const,
+			'polynomial': polynomial,
+			'state_width': state_width,
+			'io_width': io_width,
+			'seed': seed,
+			'kind': kind,
+			'direction': direction,
+			'feed_forward': feed_forward,
+		}
 
-	@ToriiTestCase.simulation
-	@ToriiTestCase.sync_domain(domain = 'sync')
-	def test_lfsr(self):
-		for _ in range(4096):
-			yield
-			yield
+		@ToriiTestCase.simulation
+		@ToriiTestCase.sync_domain(domain = 'sync')
+		def lfsr_test(self):
 
-class LFSR3TestCase(ToriiTestSuiteCase):
-	dut: LFSR | type[LFSR] = LFSR
-	dut_args = {
-		'polynomial': (1 << 16) | (1 << 14) | (1 << 13) | ( 1 << 11) | (1 << 0), # x^16 + x^14 + x^13 + x^11 + x^0
-		'state_width': 16,
-		'io_width': 1,
-		'seed': 0x8735,
-		'kind': LFSRKind.Fibonacci,
-		'direction': LFSRDir.LSb,
-	}
+			cycle_count = (2 ** self.dut.state.width) - 1
+			self.assertEqual((yield self.dut.state), self.dut_args['seed'])
 
-	def setUp(self) -> None:
-		super().setUp()
-		from torii.back.verilog import convert
-		with open('/tmp/lfsr.v', 'w') as f:
-			lfsr = LFSR(**self.dut_args)
-			f.write(convert(lfsr, 'lfsr', ports = [ lfsr._state, lfsr.input, lfsr.output ]))
-
-	@ToriiTestCase.simulation
-	@ToriiTestCase.sync_domain(domain = 'sync')
-	def test_lfsr(self):
-		init = (yield self.dut._state)
-		count = 0
-		while True:
-			count += 1
-			yield
-			if (yield self.dut._state) == init:
+			while cycle_count > 1:
 				yield
-				break
+				cycle_count -= 1
+
+			self.assertEqual((yield self.dut.state), self.dut_args['seed'])
+
+	# XXX(aki): Ignore this unholy mess
+	test_name_stub = get_var_name()
+	_LFSRTestCase.__name__ = f'{test_name_stub}TestCase'
+	setattr(_LFSRTestCase, f'test_lfsr_{test_name_stub}', _LFSRTestCase.lfsr_test)
+
+	return _LFSRTestCase
+
+
+PRBS7 = make_lfsr_test(
+	polynomial   = (1 << 7) | (1 << 6) | (1 << 0), # x^7 + x^6 + x^0
+	state_width  = 7,
+	io_width     = 1,
+	seed         = 0x2,
+	kind         = LFSRKind.Galois,
+	direction    = LFSRDir.MSb,
+	feed_forward = False
+)
+
+Generic = make_lfsr_test(
+	polynomial   = (1 << 16) | (1 << 14) | (1 << 13) | ( 1 << 11) | (1 << 0), # x^16 + x^14 + x^13 + x^11 + x^0
+	state_width  = 16,
+	io_width     = 1,
+	seed         = 0x8735,
+	kind         = LFSRKind.Fibonacci,
+	direction    = LFSRDir.LSb,
+	feed_forward = False
+)

--- a/tests/lib/test_lfsr.py
+++ b/tests/lib/test_lfsr.py
@@ -41,3 +41,33 @@ class LFSR2TestCase(ToriiTestSuiteCase):
 		for _ in range(4096):
 			yield
 			yield
+
+class LFSR3TestCase(ToriiTestSuiteCase):
+	dut: LFSR | type[LFSR] = LFSR
+	dut_args = {
+		'polynomial': (1 << 16) | (1 << 14) | (1 << 13) | ( 1 << 11) | (1 << 0), # x^16 + x^14 + x^13 + x^11 + x^0
+		'state_width': 16,
+		'io_width': 1,
+		'seed': 0x8735,
+		'kind': LFSRKind.Fibonacci,
+		'direction': LFSRDir.LSb,
+	}
+
+	def setUp(self) -> None:
+		super().setUp()
+		from torii.back.verilog import convert
+		with open('/tmp/lfsr.v', 'w') as f:
+			lfsr = LFSR(**self.dut_args)
+			f.write(convert(lfsr, 'lfsr', ports = [ lfsr._state, lfsr.input, lfsr.output ]))
+
+	@ToriiTestCase.simulation
+	@ToriiTestCase.sync_domain(domain = 'sync')
+	def test_lfsr(self):
+		init = (yield self.dut._state)
+		count = 0
+		while True:
+			count += 1
+			yield
+			if (yield self.dut._state) == init:
+				yield
+				break

--- a/tests/lib/test_lfsr.py
+++ b/tests/lib/test_lfsr.py
@@ -18,7 +18,10 @@ class LFSR_DUT(Elaboratable):
 
 		m.submodules.lfsr = lfsr = LFSR(**self.lfsr_args)
 
-		self.state = lfsr.state
+		self.output = lfsr.output
+		self.input  = lfsr.input
+		self.state  = lfsr.state
+		self.en     = lfsr.en
 
 		if self.loopback:
 			m.d.comb += [

--- a/tests/lib/test_lfsr.py
+++ b/tests/lib/test_lfsr.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+from torii.lib.lfsr import LFSR, LFSRDir, LFSRKind
+from torii.test     import ToriiTestCase
+
+from ..utils        import ToriiTestSuiteCase
+
+class LFSRTestCase(ToriiTestSuiteCase):
+	dut: LFSR | type[LFSR] = LFSR
+	dut_args = {
+		'polynomial': (1 << 7) | (1 << 6) | (1 << 0), # x^7 + x^6 + x^0
+		'state_width': 7,
+		'io_width': 1,
+		'seed': 0x2,
+		'kind': LFSRKind.Galois,
+		'direction': LFSRDir.LSb,
+	}
+
+	@ToriiTestCase.simulation
+	@ToriiTestCase.sync_domain(domain = 'sync')
+	def test_lfsr(self):
+		for _ in range(4096):
+			yield
+			yield
+
+
+class LFSR2TestCase(ToriiTestSuiteCase):
+	dut: LFSR | type[LFSR] = LFSR
+	dut_args = {
+		'polynomial': (1 << 16) | (1 << 14) | (1 << 13) | ( 1 << 11) | (1 << 0), # x^16 + x^14 + x^13 + x^11 + x^0
+		'state_width': 16,
+		'io_width': 1,
+		'seed': 0xACE1,
+		'kind': LFSRKind.Galois,
+		'direction': LFSRDir.LSb,
+	}
+
+	@ToriiTestCase.simulation
+	@ToriiTestCase.sync_domain(domain = 'sync')
+	def test_lfsr(self):
+		for _ in range(4096):
+			yield
+			yield

--- a/torii/lib/lfsr.py
+++ b/torii/lib/lfsr.py
@@ -48,7 +48,8 @@ class LFSR(Elaboratable):
 	'''
 
 	def __init__(
-		self, *, polynomial: int, state_width: int, io_width: int, seed: int, kind: LFSRKind, direction: LFSRDir
+		self, *, polynomial: int, state_width: int, io_width: int, seed: int, kind: LFSRKind, direction: LFSRDir,
+		feed_forward: bool
 	) -> None:
 
 		# Clip the seed so it fits into our LFSR
@@ -64,9 +65,10 @@ class LFSR(Elaboratable):
 		if io_width != 1 and kind == LFSRKind.Fibonacci:
 			raise ValueError('Fibonacci-type LFSRs can not have an IO width of more than one bit')
 
-		self._seed = seed
-		self._kind = kind
-		self._dir  = direction
+		self._seed         = seed
+		self._kind         = kind
+		self._dir          = direction
+		self._feed_forward = feed_forward
 
 		# Adjust the polynomial so it's correct
 		match self._dir:
@@ -189,7 +191,7 @@ class LFSR(Elaboratable):
 			case LFSRKind.Fibonacci:
 				self._generate_fibonacci(m)
 
-		if False:
+		if self._feed_forward:
 			m.d.comb += [
 				self._input.eq(self.output ^ self.input)
 			]

--- a/torii/lib/lfsr.py
+++ b/torii/lib/lfsr.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+import warnings
+
+from enum            import Enum, auto, unique
+
+from ..hdl.ir        import Elaboratable
+from ..hdl.dsl       import Module
+from ..hdl.ast       import Cat, Const, Signal, ValueDict, Slice
+from ..util.units    import bits_for
+from ..util          import flatten
+
+__all__ = (
+	'LFSR',
+	'LFSRKind',
+	'LFSRDir',
+)
+
+@unique
+class LFSRKind(Enum):
+	Galois    = auto()
+	Fibonacci = auto()
+
+@unique
+class LFSRDir(Enum):
+	MSb = auto()
+	LSb = auto()
+
+class LFSR(Elaboratable):
+	'''
+	A simple linear-feedback shift register.
+
+	Attributes
+	----------
+	state : Signal[width]
+		The current state of the LFSR.
+
+	Parameters
+	----------
+	polynomial : int
+		The polynomial the LFSR implements.
+
+	width : int
+		How many bits wide the LFSR is.
+
+	seed : int
+		The initial starting seed value for the LFSR.
+	'''
+
+	def __init__(
+		self, *, polynomial: int, state_width: int, io_width: int, seed: int, kind: LFSRKind, direction: LFSRDir
+	) -> None:
+
+		# Clip the seed so it fits into our LFSR
+		poly_width = bits_for(polynomial)
+		if poly_width > state_width + 1:
+			warnings.warn(
+				f'The polynomial {polynomial:X} is too wide for the LFSR ({poly_width} > {state_width}) '
+				'and will be truncated.',
+				RuntimeWarning, stacklevel = 2
+			)
+
+		self._seed = seed
+		self._kind = kind
+		self._dir  = direction
+
+		# Adjust the polynomial so it's correct
+		match self._dir:
+			case LFSRDir.LSb:
+				self._polynomial  = polynomial >> 1
+			case LFSRDir.MSb:
+				self._polynomial  = (polynomial << 1) & ((1 << poly_width) - 1)
+
+		self._state = Signal(state_width, reset = seed)
+		self._input = Signal(io_width)
+		self.input  = Signal(io_width)
+		self.output = Signal(io_width)
+
+	def _generate_galois(self, m: Module) -> None:
+
+		input_bits = [ self._input[bit] for bit in range(self._input.width) ]
+		lfsr: list[Slice | list[Const | Slice]] = [ self._state[bit] for bit in range(self._state.width) ]
+
+		for input_bit in input_bits:
+			taps = { bit: [] for bit in range(self._state.width) }
+			# Iterate over all the bits within the state vector
+			for lfsr_bit in range(self._state.width):
+				# Ensure the correct bit positions are picked depending on our shift-direction
+				match self._dir:
+					case LFSRDir.LSb:
+						if lfsr_bit != self._state.width - 1:
+							tap_bit = lfsr[lfsr_bit + 1]
+						else:
+							tap_bit = Const(0)
+					case LFSRDir.MSb:
+						if lfsr_bit != 0:
+							tap_bit = lfsr[lfsr_bit - 1]
+						else:
+							tap_bit = Const(0)
+
+				# Check to see if we need to insert a tap to XOR with the output
+				if self._polynomial & (1 << lfsr_bit):
+					taps[lfsr_bit] = [ tap_bit, input_bit ]
+				else:
+					taps[lfsr_bit] = [ tap_bit ]
+
+			# Optimize the XOR expressions
+			for bit in range(self._state.width):
+				state_bit: list[Slice | Const] = list(flatten(taps[bit]))
+
+				ones = 0
+				signal_bits = ValueDict[int]()
+
+				for signal_bit in state_bit:
+					if isinstance(signal_bit, Slice):
+						signal_bits[signal_bit] = signal_bits.get(signal_bit, 0) + 1
+					elif signal_bit.value == 1:
+						ones += 1
+
+				result = list[Slice | Const]()
+
+				for signal_bit, count in signal_bits.items():
+					if (count & 1) == 1:
+						result.append(signal_bit)
+				if (ones & 1) == 1:
+					result.append(Const(1))
+
+				lfsr[bit] = result
+
+		# Emit the XORs for all the taps after optimization
+		for bit in range(self._state.width):
+			m.d.sync += [
+				self._state[bit].eq(Cat(lfsr[bit]).xor()),
+			]
+
+	def _generate_fibonacci(self, m: Module) -> None:
+		pass
+
+	def elaborate(self, platform) -> Module:
+		m = Module()
+
+		match self._kind:
+			case LFSRKind.Galois:
+				self._generate_galois(m)
+			case LFSRKind.Fibonacci:
+				self._generate_fibonacci(m)
+
+		match self._dir:
+			case LFSRDir.LSb:
+				m.d.comb += [
+					self.output.eq(self._state[0]),
+				]
+			case LFSRDir.MSb:
+				m.d.comb += [
+					self.output.eq(self._state[-1]),
+				]
+
+		if False:
+			m.d.comb += [
+				self._input.eq(self.output ^ self.input)
+			]
+		else:
+			m.d.comb += [
+				self._input.eq(self.input)
+			]
+
+		# HACK(aki): Delete
+		m.d.comb += [
+			self.input.eq(self.output),
+		]
+
+		return m


### PR DESCRIPTION
This PR adds a new LFSR generator module based on the work done in the CRC module, and extends it so it can be used for more things, such as `NbMb` (de)scramblers, PRBS Generators, and anything else that needs an LFSR.

It's currently busted, and doesn't have good tests, but getting a draft PR open so it's not lost/forgotten about, hopefully we can get it fixedup and working in the next little bit.

Eventually once this is tested, and implemented well enough, the Combinatorial CRC could be implemented using this.