### PR TITLE
docs: Added new `watch-docs` nox session

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,8 @@ The general overall guidelines in [development and testing] also apply to any an
 
 To generate a local version of the documentation, run `nox -s build-docs`, this will set up everything needed to build the documentation, and then produce a rendered output result in `build/docs`.
 
+When working on the documentation, having to re-build after every change can be rough, so that's where the `nox -s watch-docs` comes in. When run, it will build the initial current version of the docs, then start a local web-server up on `http://127.0.0.1:8000` to view the docs. Whenever you then make a change to any of the files in `docs/`, it will automatically re-build the documentation and then re-load the page opened in the browser.
+
 To check to make sure all links are live, the `nox -s linkcheck-docs` command can be used, this will build the documentation and then check each and every hyperlink found within it to make sure it is reachable. This is also done in CI and is a hard-requirement for the documentation to be deployed, so if any of the links are dead, the documentation will not be updated on the live site.
 
 ## AI Usage Policy

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,6 +82,14 @@ def test(session: Session) -> None:
 			f'--rcfile={CNTRB_DIR / "coveragerc"}'
 		)
 
+@nox.session(name = 'watch-docs')
+def watch_docs(session: Session) -> None:
+	out_dir = (BUILD_DIR / 'docs')
+	session.install('-r', str(DOCS_DIR / 'requirements.txt'))
+	session.install('sphinx-autobuild')
+	session.install('.')
+	session.run('sphinx-autobuild', str(DOCS_DIR), str(out_dir))
+
 @nox.session(name = 'build-docs')
 def build_docs(session: Session) -> None:
 	out_dir = (BUILD_DIR / 'docs')


### PR DESCRIPTION
This PR adds a new `nox` session, `watch-docs`, This uses `sphinx-autobuild` to spin up a dev web server on `https://127.0.0.1:8000` to serve the built docs and it will watch the contents of `docs/` for any changes. When something changes it will re-build the docs then re-load the web page.