### PR TITLE
Bump minimum Python version from 3.10 to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', ]
+        python-version: [ '3.11', '3.12', '3.13', ]
         torii-formal:
          - false
         allow-failure:
@@ -74,9 +74,6 @@ jobs:
             allow-failure: true
             torii-formal: false
           - python-version: 'pypy3.11'
-            allow-failure: true
-            torii-formal: false
-          - python-version: 'pypy3.10'
             allow-failure: true
             torii-formal: false
           - python-version: '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ Unreleased template stuff
 
 ## [Unreleased]
 
+> [!IMPORTANT]
+> The minimum Python version for Torii is now 3.11
+
 ### Added
 
 - Introduced a new global warning handler for Torii to allow for rendering warnings with syntax highlighted context.
 
 ### Changed
 
+- Minimum Python version has been bumped from `3.10` to `3.11`.
 - Altered the license for the Torii documentation going forward, all past contributions will remain under the [BSD-2-Clause] until they are re-written/superseded and all new/future contributions to the documentation will be under the [CC-BY-SA 4.0].
 - Switched from using the old setuptools `setup.py` over to setuptools via `pyproject.toml`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Unreleased template stuff
 - Removed the deprecated `torii.lib.soc.wishbone` module, it has been moved to `torii.lib.bus.wishbone`.
 - Removed the deprecated `connect` method in favor of `attach` and the `payload` signal in favor of `data` from `torii.lib.stream.simple`.
 - Removed the deprecated `rdy` and `ack` signals in `torii.lib.stdio.serial.AsyncSerialRX` in favor of `done` andd `start` respectively.
+- Removed the dependency on the `typing_extensions` module.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ['version']
 license = 'BSD-3-Clause'
 license-files = ['LICENSE', 'LICENSE.docs']
 readme = 'README.md'
-requires-python = '~=3.10'
+requires-python = '~=3.11'
 dependencies = [
 	# NOTE(aki):
 	# Having setuptools as a runtime dep feels weird, but we are using the `_distutils`
@@ -25,7 +25,6 @@ dependencies = [
 	'pyvcd>=0.4.0,<0.5',
 	'Jinja2~=3.0',
 	'rich>=13.6.0',
-	'typing-extensions; python_version<"3.12"',
 ]
 keywords = [
 	'HDL',
@@ -48,7 +47,6 @@ classifiers = [
 	'Operating System :: Microsoft :: Windows',
 	'Operating System :: POSIX :: Linux',
 
-	'Programming Language :: Python :: 3.10',
 	'Programming Language :: Python :: 3.11',
 	'Programming Language :: Python :: 3.12',
 	'Programming Language :: Python :: 3.13',

--- a/tests/lib/hash/test_crc.py
+++ b/tests/lib/hash/test_crc.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from collections.abc    import Iterable
+
 from zlib               import crc32
-from typing             import Iterable
 
 from torii.lib.hash.crc import BitwiseCRC, LUTBytewiseCRC, CombBytewiseCRC
 from torii.test         import ToriiTestCase

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -14,14 +14,10 @@ from collections.abc   import (
 )
 from enum              import Enum, EnumMeta
 from itertools         import chain
-from sys               import version_info
 from types             import NotImplementedType
-from typing            import TYPE_CHECKING, Generic, Literal, NoReturn, ParamSpec,  SupportsIndex, TypeAlias, TypeVar
-
-if version_info < (3, 12):
-	from typing_extensions import TypeVarTuple, Unpack
-else:
-	from typing        import TypeVarTuple, Unpack
+from typing            import (
+	TYPE_CHECKING, Generic, Literal, NoReturn, ParamSpec,  SupportsIndex, TypeAlias, TypeVar, TypeVarTuple
+)
 
 from .._typing         import SrcLoc, SwitchCaseT
 from ..util            import flatten, tracer, union
@@ -1262,7 +1258,7 @@ SignalAttrs: TypeAlias = dict[str, int | str | bool]
 SignalDecoder: TypeAlias = Callable[[int], str] | type[Enum]
 _SigParams = TypeVarTuple('_SigParams')
 # @final
-class Signal(Value, DUID, Generic[Unpack[_SigParams]]):
+class Signal(Value, DUID, Generic[*_SigParams]):
 	'''
 	A varying integer value.
 

--- a/torii/util/tracer.py
+++ b/torii/util/tracer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from opcode    import opname
-from sys       import _getframe, implementation, version_info
+from sys       import _getframe, implementation
 from typing    import TYPE_CHECKING
 
 from .._typing import SrcLoc
@@ -76,19 +76,17 @@ def get_var_name(depth: int = 2, default: str | object = _raise_exception) -> st
 			return code.co_names[imm]
 		elif opc == 'STORE_FAST':
 			imm |= int(code.co_code[index + 1])
-			if version_info >= (3, 11) and not _IS_PYPY:
-				return code._varname_from_oparg(imm) # type: ignore
-			else:
+			if _IS_PYPY:
 				return code.co_varnames[imm]
+			return code._varname_from_oparg(imm) # type: ignore
 		elif opc == 'STORE_DEREF':
 			imm |= int(code.co_code[index + 1])
-			if version_info >= (3, 11) and not _IS_PYPY:
-				return code._varname_from_oparg(imm) # type: ignore
-			else:
+			if _IS_PYPY:
 				if imm < len(code.co_cellvars):
 					return code.co_cellvars[imm]
 				else:
 					return code.co_freevars[imm - len(code.co_cellvars)]
+			return code._varname_from_oparg(imm) # type: ignore
 		elif opc in (
 			'LOAD_GLOBAL', 'LOAD_NAME', 'LOAD_ATTR', 'LOAD_FAST', 'LOAD_FAST_BORROW',
 			'LOAD_DEREF', 'DUP_TOP', 'BUILD_LIST', 'CACHE', 'COPY'

--- a/torii/warnings.py
+++ b/torii/warnings.py
@@ -13,7 +13,7 @@ import warnings
 from linecache    import getline, getlines
 from os           import getenv
 from pathlib      import Path
-from sys          import stdout, version_info
+from sys          import stdout
 from typing       import Final, TextIO, TypedDict
 
 from rich         import get_console
@@ -225,8 +225,7 @@ def _warning_handler( # :nocov:
 		category = message.__class__
 
 		# If we are in Python 3.11 or newer, then we can have attached notes
-		if version_info >= (3, 11):
-			notes = getattr(message, '__notes__', None)
+		notes = getattr(message, '__notes__', None)
 		message  = str(message)
 
 	# If the category is `None`, then we need to just say it's a generic warning


### PR DESCRIPTION
This PR bumps the minimum version of Python from 3.10 to 3.11.

Doing so allowed us to drop the `typing_extensions` dependency, and also simplify a few code paths as we no longer need to maintain compatibility with 3.10