### PR TITLE
Fixed multi-versioned docs titles

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -5,6 +5,16 @@
 #}
 {% extends "base.html" %}
 
+{%- if current_version %}
+{%- block htmltitle -%}
+{% if pagename == master_doc %}
+<title>{{ project|striptags|e }} {{ current_version.name if current_version.is_released else release }} Documentation</title>
+{% else %}
+<title>{{ title|striptags|e }} - {{ project|striptags|e }} {{ current_version.name if current_version.is_released else release }} Documentation</title>
+{% endif %}
+{%- endblock %}
+{%- endif %}
+
 {% block body -%}
 {{ super() }}
 {% include "partials/icons.html" %}

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,28 @@
+{#
+	SPDX-License-Identifier: MIT
+
+	We copy in the original brand template from Furo here so we can muck with the name
+#}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+	{%- block brand_content %}
+	{#- Remember to update the prefetch logic in `block logo_prefetch_links` in base.html #}
+	{%- if logo_url %}
+	<div class="sidebar-logo-container">
+	  <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+	</div>
+	{%- endif %}
+	{%- if theme_light_logo and theme_dark_logo %}
+	<div class="sidebar-logo-container">
+	  <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+	  <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+	</div>
+	{%- endif %}
+	{%- if current_version %}
+	<span class="sidebar-brand-text">{{ project }} {{ current_version.name if current_version.is_released else release }} Documentation</span>
+	{%- else -%}
+	{% if not theme_sidebar_hide_name %}
+	<span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+	{%- endif %}
+	{%- endif %}
+	{% endblock brand_content %}
+  </a>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR alters the docs templates to fix the titles for the documentation to ensure that it shows the correct version rather than always showing the latest version even for the old docs.

This is a temporary patch until we can replace `sphinx-multiversion` and maybe even a custom theme.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
