### PR TITLE
Add JSON netlist backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Unreleased template stuff
 ### Added
 
 - Introduced a new global warning handler for Torii to allow for rendering warnings with syntax highlighted context.
+- New `torii.back.json` backend to emit JSON netlists for designs.
 
 ### Changed
 

--- a/docs/api/backend/index.md
+++ b/docs/api/backend/index.md
@@ -5,9 +5,9 @@ The Torii API reference is a work in progress and we are actively working on imp
 however it may be deficient or missing in places.
 ```
 
-Torii has 3 primary backends, [RTLIL], [Verilog], and [CXXRTL], each takes a Torii {py:class}`Fragment <torii.hdl.ir.Fragment>` or {py:class}`Elaboratable <torii.hdl.ir.Elaboratable>` and produces an RTL netlist in the given output format.
+Torii has 3 primary backends, [RTLIL], [Verilog], and [CXXRTL], each takes a Torii {py:class}`Fragment <torii.hdl.ir.Fragment>` or {py:class}`Elaboratable <torii.hdl.ir.Elaboratable>` and produces an RTL netlist in the given output format. There is also the [JSON] backend for generic netlist output.
 
-The primary lingua franca of the Torii backends is [RTLIL], the [Verilog] and [CXXRTL] backends first convert the IR into it, and then use [Yosys] to convert the RTLIL netlist into their respective output formats
+The primary lingua franca of the Torii backends is [RTLIL], the [Verilog], [CXXRTL], and [JSON] backends first convert the IR into it, and then use [Yosys] to convert the RTLIL netlist into their respective output formats
 
 ## RTLIL Backend
 
@@ -29,6 +29,14 @@ The primary lingua franca of the Torii backends is [RTLIL], the [Verilog] and [C
 
 ```{eval-rst}
 .. automodule:: torii.back.cxxrtl
+  :members:
+
+```
+
+## JSON Backend
+
+```{eval-rst}
+.. automodule:: torii.back.json
   :members:
 
 ```
@@ -102,4 +110,5 @@ endmodule
 [RTLIL]: https://yosyshq.readthedocs.io/projects/yosys/en/latest/appendix/rtlil_text.html
 [Verilog]: https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/write_verilog.html
 [CXXRTL]: https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/write_cxxrtl.html
+[JSON]: https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/write_json.html
 [Yosys]: https://github.com/YosysHQ/yosys

--- a/torii/back/json.py
+++ b/torii/back/json.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+from ..hdl.ast     import SignalDict
+from ..hdl.cd      import ClockDomain
+from ..hdl.ir      import Elaboratable, Fragment
+from ..tools.yosys import find_yosys
+from .             import rtlil
+
+__all__ = (
+	'convert_fragment',
+	'convert',
+)
+
+def _convert_rtlil_text(rtlil_text: str, *, write_json_opts: tuple[str, ...] = ()) -> str:
+
+	yosys = find_yosys()
+
+	script = []
+	script.append(f'read_rtlil <<rtlil\n{rtlil_text}\nrtlil')
+
+	script.append('proc -noopt -norom')
+	script.append('memory_collect')
+
+	script.append(f'write_json {" ".join(write_json_opts)}')
+
+	return yosys.run(['-q', '-'], '\n'.join(script))
+
+def convert_fragment(fragment: Fragment, name: str = 'top', emit_src: bool = True) -> tuple[str, SignalDict]:
+	'''
+	Recursively lower the given Torii :py:class:`Fragment <torii.hdl.ir.Fragment>` into a JSON netlist and
+	a signal map.
+
+	Parameters
+	----------
+	fragment : torii.hdl.ir.Fragment
+		The Torii fragment hierarchy to lower.
+
+	name : str
+		The name of the root fragment module.
+
+	emit_src : bool
+		Emit source line attributes in the resulting JSON.
+
+	Returns
+	-------
+	tuple[str, torii.hdl.ast.SignalDict]
+		The JSON netlist and signal dictionary of the lowered fragment.
+	'''
+
+	rtlil_text, name_map = rtlil.convert_fragment(fragment, name, emit_src = emit_src)
+	return (_convert_rtlil_text(rtlil_text), name_map)
+
+def convert(
+	elaboratable: Fragment | Elaboratable, name: str = 'top', platform = None, *, ports,
+	emit_src: bool = True, strip_internal_attrs: bool = False, missing_domain = lambda name: ClockDomain(name)
+) -> str:
+	'''
+	Convert the given Torii :py:class:`Elaboratable <torii.hdl.ir.Elaboratable>` into a JSON netlist.
+
+	Parameters
+	----------
+	elaboratable : torii.hdl.ir.Elaboratable
+		The Elaboratable to write the JSON netlist for.
+
+	name : str
+		The name of the resulting JSON netlist.
+
+	platform : torii.build.plat.Platform
+		The platform to use for Elaboratable evaluation.
+
+	ports : list[]
+		The list of ports on the top-level module.
+
+	emit_src : bool
+		Emit source line attributes in the final JSON netlist.
+
+	Returns
+	-------
+	str
+		The resulting JSON netlist.
+	'''
+
+	fragment = Fragment.get(elaboratable, platform).prepare(ports = ports, missing_domain = missing_domain)
+	json_netlist, _ = convert_fragment(fragment, name, emit_src = emit_src)
+	return json_netlist


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds a new `torii.back.json` module which exposes the same `convert` and `convert_fragment` calls the Verilog and CXXRTL backends have.

The output is the result from the yosys [`write_json`](https://yosyshq.readthedocs.io/projects/yosys/en/latest/cmd/write_json.html) call after a `proc -noopt -norom` and `memory_collect`.

It's not super applicable in general, but can be used for integration into other things that consume the Yosys JSON netlist format.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
