### PR TITLE
Add `from_khz`/`from_mhz`/`from_ghz` to `torii.build.dsl.Clock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased template stuff
 - Introduced a new global warning handler for Torii to allow for rendering warnings with syntax highlighted context.
 - New `torii.back.json` backend to emit JSON netlists for designs.
 - Added `det` pin to `torii.platforms.resources.memory.SDCardResources` for hot-plug SD Card detection.
+- New `.from_khz`, `.from_mhz`, and `from_ghz`, on the `torii.build.dsl.Clock` to create a new clock resource from more than just Hz.
 
 ### Changed
 

--- a/tests/build/test_dsl.py
+++ b/tests/build/test_dsl.py
@@ -175,6 +175,24 @@ class ClockTestCase(ToriiTestSuiteCase):
 		self.assertEqual(c.period, 1e-6)
 		self.assertEqual(repr(c), '(clock 1000000.0)')
 
+	def test_from_khz(self):
+		c = Clock.from_khz(20)
+		self.assertEqual(c.frequency, 20e3)
+		self.assertEqual(c.period, 50e-6)
+		self.assertEqual(repr(c), '(clock 20000.0)')
+
+	def test_from_mhz(self):
+		c = Clock.from_mhz(300)
+		self.assertEqual(c.frequency, 300e6)
+		self.assertAlmostEqual(c.period, 300e-11)
+		self.assertEqual(repr(c), '(clock 300000000.0)')
+
+	def test_from_ghz(self):
+		c = Clock.from_ghz(8)
+		self.assertEqual(c.frequency, 8e9)
+		self.assertAlmostEqual(c.period, 8e-15)
+		self.assertEqual(repr(c), '(clock 8000000000.0)')
+
 class SubsignalTestCase(ToriiTestSuiteCase):
 	def test_basic_pins(self):
 		s = Subsignal('a', Pins('A0'), Attrs(IOSTANDARD = 'LVCMOS33'))

--- a/torii/build/dsl.py
+++ b/torii/build/dsl.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Generator, Iterator, Sequence
 from typing          import TypeAlias
 
 from .._typing       import IODirectionOE
+from ..util.units    import GIGA, KILO, MEGA
 
 __all__ = (
 	'Attrs',
@@ -127,6 +128,54 @@ class Clock:
 			raise TypeError('Clock frequency must be a number')
 
 		self.frequency = float(frequency)
+
+	@classmethod
+	def from_khz(cls: type['Clock'], frequency: float | int) -> 'Clock':
+		'''
+		Create a new Clock resource with the given frequency in kHz.
+
+		Parameters
+		----------
+		frequency: float | int
+			The frequency of the clock in kilohertz.
+
+		Returns
+		-------
+		Clock
+		'''
+		return Clock(frequency * KILO)
+
+	@classmethod
+	def from_mhz(cls: type['Clock'], frequency: float | int) -> 'Clock':
+		'''
+		Create a new Clock resource with the given frequency in MHz.
+
+		Parameters
+		----------
+		frequency: float | int
+			The frequency of the clock in megahertz.
+
+		Returns
+		-------
+		Clock
+		'''
+		return Clock(frequency * MEGA)
+
+	@classmethod
+	def from_ghz(cls: type['Clock'], frequency: float | int) -> 'Clock':
+		'''
+		Create a new Clock resource with the given frequency in GHz.
+
+		Parameters
+		----------
+		frequency: float | int
+			The frequency of the clock in gigahertz.
+
+		Returns
+		-------
+		Clock
+		'''
+		return Clock(frequency * GIGA)
 
 	@property
 	def period(self) -> float:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

When creating a `Clock` resource, the only current way is to specify the frequency in Hertz. This can be error-prone, I myself have accidentally turned MHz into GHz by forgetting the correct exponent to suffix the number with.

This PR adds 3 class methods to `torii.build.dsl.Clock`:

* `from_khz` - Create a new `Clock` from the provided frequency in kHz
* `from_mhz` - Create a new `Clock` from the provided frequency in MHz
* `from_ghz` - Create a new `Clock` from the provided frequency in GHz

For instance, to create a 20MHz Clock:
```py
# Old
clk = Clock(20e6)
# New
clk = Clock.from_mhz(20)
```

Normally only kHz and MHz would be needed, but I added GHz support for future proofing, and it may be used in ASIC designs.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
