### PR TITLE
Feature: Add new `HDMIResource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Unreleased template stuff
 - New `torii.back.json` backend to emit JSON netlists for designs.
 - Added `det` pin to `torii.platforms.resources.memory.SDCardResources` for hot-plug SD Card detection.
 - New `.from_khz`, `.from_mhz`, and `from_ghz`, on the `torii.build.dsl.Clock` to create a new clock resource from more than just Hz.
+- Added new `HDMIResource` for HDMI port resources on board platforms.
 
 ### Changed
 

--- a/torii/platform/resources/__init__.py
+++ b/torii/platform/resources/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from .display    import Display7SegResource, VGADACResource, VGAResource
+from .display    import Display7SegResource, HDMIResource, VGADACResource, VGAResource
 from .extensions import (
 	PmodDualHBridgeType6Resource, PmodGPIOType1Resource, PmodHBridgeType5Resource, PmodSPIType2AResource,
 	PmodSPIType2Resource, PmodUARTType3Resource, PmodUARTType4AResource, PmodUARTType4Resource,
@@ -16,6 +16,7 @@ from .user       import ButtonResources, LEDResources, RGBLEDResource, SwitchRes
 
 __all__ = (
 	'Display7SegResource',
+	'HDMIResource',
 	'VGADACResource',
 	'VGAResource',
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR is fairly straightforward, it adds a new `HDMIResource` to `torii.platform.resources.display`.

A handful of our board platforms in `torii_boards` have HDMI ports and were using manual `Resource`'s, and I suspect many users were too, so this should clean that up a little bit.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
