### PR TITLE
deps: Bump `Jinja2` and `rich` minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Unreleased template stuff
 - Minimum Python version has been bumped from `3.10` to `3.11`.
 - Altered the license for the Torii documentation going forward, all past contributions will remain under the [BSD-2-Clause] until they are re-written/superseded and all new/future contributions to the documentation will be under the [CC-BY-SA 4.0].
 - Switched from using the old setuptools `setup.py` over to setuptools via `pyproject.toml`
+- Bumped Jinja2 version to `~=3.1`
+- Bumped rich version to `>=13.7.0`
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
 	# things needed before we can drop this runtime dep is long.
 	'setuptools>=66',
 	'pyvcd>=0.4.0,<0.5',
-	'Jinja2~=3.0',
-	'rich>=13.6.0',
+	'Jinja2~=3.1',
+	'rich>=13.7.0',
 ]
 keywords = [
 	'HDL',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR bumps the Jinja2 dep from `~=3.0` to `~=3.1` and rich from `>=13.6.0` to `>=13.7.0`

Jinja2 is currently at `3.1.6` and rich at `14.1.0` so this is a very *very* minor bump in the grand scheme of things.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
