### PR TITLE
Fixed the `torii.build.plat.Platform` `_check_feature`  function, and ensure `get_diff_*` throw when used but unimplemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Unreleased template stuff
   - Subdivided `torii.platform.resources.interface` into `.bus`, `.network`, and `.serial`.
   - Subdivided `torii.platform.resources.memory` into `.ram` and `.flash`.
   - `HyperBusResource` now lives in `torii.platform.resources.memory`
+- The `torii.build.plat` module now has a `PinFeature` enum which replaces the strings used to pass to the `_check_feature` calls for platform implementation.
+- The `torii.build.plat` `get_*` functions now take in the list of pin names when generating buffers, to allow for special casing on pin sites as needed.
 
 ### Deprecated
 

--- a/torii/build/__init__.py
+++ b/torii/build/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from .dsl                 import Attrs, Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Resource, Subsignal
-from .plat                import Platform, TemplatedPlatform
+from .plat                import PinFeature, Platform, TemplatedPlatform
 from ..diagnostics.errors import ResourceError
 
 __all__ = (
@@ -12,6 +12,7 @@ __all__ = (
 	'DiffPairsN',
 	'Pins',
 	'PinsN',
+	'PinFeature',
 	'Platform',
 	'Resource',
 	'ResourceError',

--- a/torii/build/plat.py
+++ b/torii/build/plat.py
@@ -249,7 +249,8 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support programming')
 
 	def _check_feature(
-		self, feature: PinFeature, pin: Pin, attrs: Attrs, valid_xdrs: tuple[int, ...], valid_attrs: str | None
+		self, feature: PinFeature, pin: Pin, attrs: Attrs, valid_xdrs: tuple[int, ...], valid_attrs: str | None,
+		names: Iterable[str] | tuple[Iterable[str], Iterable[str]]
 	) -> None:
 		if len(valid_xdrs) == 0:
 			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support {feature!s}')
@@ -272,7 +273,9 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_input(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature(PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None, names = names
+		)
 
 		m = Module()
 		m.d.comb += pin.i.eq(self._invert_if(invert, port))
@@ -281,7 +284,9 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature(PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None, names = names
+		)
 
 		m = Module()
 		m.d.comb += port.eq(self._invert_if(invert, pin.o))
@@ -290,7 +295,9 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature(PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0,), valid_attrs = None, names = names
+		)
 
 		m = Module()
 		m.submodules += Instance(
@@ -305,7 +312,9 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature(PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None, names = names
+		)
 
 		m = Module()
 		m.submodules += Instance(
@@ -321,22 +330,30 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_diff_input(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature(PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
+		)
 
 	def get_diff_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature(PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
+		)
 
 	def get_diff_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature(PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
+		)
 
 	def get_diff_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature(PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
+		)
 
 class TemplatedPlatform(Platform):
 	@property

--- a/torii/build/plat.py
+++ b/torii/build/plat.py
@@ -334,12 +334,16 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
+		raise NotImplementedError('This platform does not support differential inputs')
+
 	def get_diff_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
 		self._check_feature(
 			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
+
+		raise NotImplementedError('This platform does not support differential outputs')
 
 	def get_diff_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
@@ -348,12 +352,16 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
+		raise NotImplementedError('This platform does not implement differential tristate')
+
 	def get_diff_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
 		self._check_feature(
 			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
+
+		raise NotImplementedError('This platform does not implement differential inputs/outputs')
 
 class TemplatedPlatform(Platform):
 	@property

--- a/torii/build/plat.py
+++ b/torii/build/plat.py
@@ -6,6 +6,7 @@ import textwrap
 from abc             import ABCMeta, abstractmethod
 from collections     import OrderedDict
 from collections.abc import Generator, Iterable
+from enum            import Enum, auto, unique
 from typing          import IO, Literal, TypeVar
 
 import jinja2
@@ -27,9 +28,40 @@ from .res            import ResourceManager
 from .run            import BuildPlan, BuildProducts
 
 __all__ = (
+	'PinFeature',
 	'Platform',
 	'TemplatedPlatform',
 )
+
+@unique
+class PinFeature(Enum):
+	DIFF_INOUT    = auto()
+	DIFF_INPUT    = auto()
+	DIFF_OUTPUT   = auto()
+	DIFF_TRISTATE = auto()
+	SE_INOUT      = auto()
+	SE_INPUT      = auto()
+	SE_OUTPUT     = auto()
+	SE_TRISTATE   = auto()
+
+	def __str__(self) -> str:
+		match self:
+			case PinFeature.DIFF_INOUT:
+				return 'differential input/output'
+			case PinFeature.DIFF_INPUT:
+				return 'differential input'
+			case PinFeature.DIFF_OUTPUT:
+				return 'differential output'
+			case PinFeature.DIFF_TRISTATE:
+				return 'differential tristate'
+			case PinFeature.SE_INOUT:
+				return 'single-ended input/output'
+			case PinFeature.SE_INPUT:
+				return 'single-ended input'
+			case PinFeature.SE_OUTPUT:
+				return 'single-ended output'
+			case PinFeature.SE_TRISTATE:
+				return 'single-ended tristate'
 
 class Platform(ResourceManager, metaclass = ABCMeta):
 	@property

--- a/torii/build/plat.py
+++ b/torii/build/plat.py
@@ -249,18 +249,18 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support programming')
 
 	def _check_feature(
-		self, feature: str, pin: Pin, attrs: Attrs, valid_xdrs: tuple[int, ...], valid_attrs: str | None
+		self, feature: PinFeature, pin: Pin, attrs: Attrs, valid_xdrs: tuple[int, ...], valid_attrs: str | None
 	) -> None:
 		if len(valid_xdrs) == 0:
-			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support {feature}')
+			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support {feature!s}')
 
 		elif pin.xdr not in valid_xdrs:
 			raise NotImplementedError(
-				f'Platform \'{type(self).__name__}\' does not support {feature} for XDR {pin.xdr}'
+				f'Platform \'{type(self).__name__}\' does not support {feature!s} for XDR {pin.xdr}'
 			)
 
 		if not valid_attrs and attrs:
-			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support attributes for {feature}')
+			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support attributes for {feature!s}')
 
 	@staticmethod
 	def _invert_if(invert: bool, value):
@@ -272,7 +272,7 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_input(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature('single-ended input', pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
 
 		m = Module()
 		m.d.comb += pin.i.eq(self._invert_if(invert, port))
@@ -281,7 +281,7 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature('single-ended output', pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
 
 		m = Module()
 		m.d.comb += port.eq(self._invert_if(invert, pin.o))
@@ -290,7 +290,7 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature('single-ended tristate', pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
 
 		m = Module()
 		m.submodules += Instance(
@@ -305,7 +305,7 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
-		self._check_feature('single-ended input/output', pin, attrs, valid_xdrs = (0,), valid_attrs = None)
+		self._check_feature(PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0,), valid_attrs = None)
 
 		m = Module()
 		m.submodules += Instance(
@@ -321,22 +321,22 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 	def get_diff_input(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature('differential input', pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
 
 	def get_diff_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature('differential output', pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
 
 	def get_diff_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature('differential tristate', pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (), valid_attrs = None)
 
 	def get_diff_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module | None:
-		self._check_feature('differential input/output', pin, attrs, valid_xdrs = (), valid_attrs = None)
+		self._check_feature(PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None)
 
 class TemplatedPlatform(Platform):
 	@property

--- a/torii/platform/vendor/altera.py
+++ b/torii/platform/vendor/altera.py
@@ -429,7 +429,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -450,7 +450,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -472,7 +472,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -495,7 +495,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -518,7 +518,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -541,7 +541,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -565,7 +565,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:
@@ -590,7 +590,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		if pin.xdr == 1:

--- a/torii/platform/vendor/altera.py
+++ b/torii/platform/vendor/altera.py
@@ -4,7 +4,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from typing          import Literal
 
-from ...build        import Attrs, Clock, TemplatedPlatform
+from ...build        import Attrs, Clock, PinFeature, TemplatedPlatform
 from ...hdl          import ClockDomain, ClockSignal, Const, Instance, Module, Record, Signal
 from ...lib.io       import Pin
 
@@ -429,7 +429,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -450,7 +450,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -472,7 +472,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -495,7 +495,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -518,7 +518,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -541,7 +541,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -565,7 +565,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:
@@ -590,7 +590,7 @@ class AlteraPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		if pin.xdr == 1:

--- a/torii/platform/vendor/gowin.py
+++ b/torii/platform/vendor/gowin.py
@@ -5,7 +5,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from fractions       import Fraction
 
-from ...build        import Attrs, Clock, TemplatedPlatform
+from ...build        import Attrs, Clock, PinFeature, TemplatedPlatform
 from ...hdl          import ClockDomain, ClockSignal, Const, Instance, Module, Record, Signal
 from ...lib.cdc      import ResetSynchronizer
 from ...lib.io       import Pin
@@ -551,7 +551,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert)
@@ -567,7 +567,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, port.io, o_invert = invert)
@@ -583,7 +583,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -600,7 +600,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert, o_invert = invert)
@@ -618,7 +618,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert)
@@ -635,7 +635,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -652,7 +652,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -670,7 +670,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert, o_invert = invert)

--- a/torii/platform/vendor/gowin.py
+++ b/torii/platform/vendor/gowin.py
@@ -551,7 +551,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert)
@@ -567,7 +567,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, port.io, o_invert = invert)
@@ -583,7 +583,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -600,7 +600,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert, o_invert = invert)
@@ -618,7 +618,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert)
@@ -635,7 +635,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -652,7 +652,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, o_invert = invert)
@@ -670,7 +670,7 @@ class GowinPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 		m = Module()
 		i, o, t = self._get_xdr_buffer(m, pin, i_invert = invert, o_invert = invert)

--- a/torii/platform/vendor/lattice/ecp5.py
+++ b/torii/platform/vendor/lattice/ecp5.py
@@ -4,7 +4,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from typing          import Literal
 
-from ....build       import Attrs, Clock, Subsignal, TemplatedPlatform
+from ....build       import Attrs, Clock, Subsignal, PinFeature, TemplatedPlatform
 from ....hdl         import ClockDomain, ClockSignal, Const, Instance, Module, Record, Signal
 from ....lib.io      import Pin
 
@@ -635,7 +635,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -652,7 +652,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -669,7 +669,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -687,7 +687,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -706,7 +706,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -723,7 +723,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -740,7 +740,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential tristate', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()
@@ -758,7 +758,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input/output', pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
 		)
 
 		m = Module()

--- a/torii/platform/vendor/lattice/ecp5.py
+++ b/torii/platform/vendor/lattice/ecp5.py
@@ -635,7 +635,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -652,7 +652,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -669,7 +669,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -687,7 +687,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -706,7 +706,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -723,7 +723,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -740,7 +740,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -758,7 +758,7 @@ class ECP5Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2, 4, 7), valid_attrs = True, names = names
 		)
 
 		m = Module()

--- a/torii/platform/vendor/lattice/ice40.py
+++ b/torii/platform/vendor/lattice/ice40.py
@@ -4,7 +4,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from typing          import Literal
 
-from ....build       import Attrs, Clock, Subsignal, TemplatedPlatform
+from ....build       import Attrs, Clock, Subsignal, PinFeature, TemplatedPlatform
 from ....hdl         import ClockDomain, ClockSignal, Const, Instance, Module, Record, ResetSignal, Signal
 from ....lib.cdc     import ResetSynchronizer
 from ....lib.io      import Pin
@@ -639,7 +639,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -650,7 +650,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -661,7 +661,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -672,7 +672,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -683,7 +683,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -695,7 +695,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()

--- a/torii/platform/vendor/lattice/ice40.py
+++ b/torii/platform/vendor/lattice/ice40.py
@@ -639,7 +639,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -650,7 +650,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -661,7 +661,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -672,7 +672,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -683,7 +683,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -695,7 +695,7 @@ class ICE40Platform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()

--- a/torii/platform/vendor/lattice/machxo_2_3l.py
+++ b/torii/platform/vendor/lattice/machxo_2_3l.py
@@ -385,7 +385,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -402,7 +402,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -419,7 +419,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -437,7 +437,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -456,7 +456,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -473,7 +473,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -490,7 +490,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -508,7 +508,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True, names = names
 		)
 
 		m = Module()

--- a/torii/platform/vendor/lattice/machxo_2_3l.py
+++ b/torii/platform/vendor/lattice/machxo_2_3l.py
@@ -4,7 +4,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from typing          import Literal
 
-from ....build       import Attrs, Clock, Subsignal, TemplatedPlatform
+from ....build       import Attrs, Clock, Subsignal, PinFeature, TemplatedPlatform
 from ....hdl         import ClockDomain, ClockSignal, Const, Instance, Module, Record, Signal
 from ....lib.io      import Pin
 
@@ -385,7 +385,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -402,7 +402,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -419,7 +419,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -437,7 +437,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -456,7 +456,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -473,7 +473,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -490,7 +490,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential tristate', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()
@@ -508,7 +508,7 @@ class MachXO2Or3LPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
 	) -> Module:
 		self._check_feature(
-			'differential input/output', pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (0, 1, 2), valid_attrs = True
 		)
 
 		m = Module()

--- a/torii/platform/vendor/xilinx.py
+++ b/torii/platform/vendor/xilinx.py
@@ -4,7 +4,7 @@ from abc             import abstractmethod
 from collections.abc import Iterable
 from typing          import Literal
 
-from ...build        import Attrs, TemplatedPlatform
+from ...build        import Attrs, PinFeature, TemplatedPlatform
 from ...hdl          import ClockDomain, ClockSignal, Const, Instance, Module, Record, ResetSignal, Signal
 from ...lib.cdc      import ResetSynchronizer
 from ...lib.io       import Pin
@@ -1120,7 +1120,7 @@ class XilinxPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended input', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1137,7 +1137,7 @@ class XilinxPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			'single-ended output', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1160,7 +1160,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_tristate(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'single-ended tristate', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1181,7 +1181,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_input_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'single-ended input/output', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1203,7 +1203,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_input(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'differential input', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1224,7 +1224,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'differential output', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1245,7 +1245,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_tristate(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'differential tristate', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()
@@ -1267,7 +1267,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_input_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			'differential input/output', pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
 		)
 
 		m = Module()

--- a/torii/platform/vendor/xilinx.py
+++ b/torii/platform/vendor/xilinx.py
@@ -1120,7 +1120,7 @@ class XilinxPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1137,7 +1137,7 @@ class XilinxPlatform(TemplatedPlatform):
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: Iterable[str]
 	) -> Module:
 		self._check_feature(
-			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1160,7 +1160,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_tristate(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1181,7 +1181,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_input_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.SE_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1203,7 +1203,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_input(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_INPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1224,7 +1224,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1245,7 +1245,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_tristate(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()
@@ -1267,7 +1267,7 @@ class XilinxPlatform(TemplatedPlatform):
 			return super().get_diff_input_output(pin, port, attrs, invert, names)
 
 		self._check_feature(
-			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True
+			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = self._get_valid_xdrs(), valid_attrs = True, names = names
 		)
 
 		m = Module()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR introduces a new enum in the `torii.build.plat` module, `PinFeature`, it is used to replace the string in the `_check_feature` call of `torii.build.plat.Platform`. 

Along with this the `_check_feature` call now accepts the pin names that were added in #89 so we can do per-platform validation there by having the platform overload it.

We also ensure that `get_diff_*` which previously did not return anything now throw a `NotImplementedException` to prevent the accidental creation of malformed gateware. 

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
