### PR TITLE
Add proper name and domain validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,21 @@ Unreleased template stuff
 
 ### Fixed
 
+- Fixed several instances where HDL constructs would accept invalid names and domains resulting in the generated RTLIL to be malformed.
+  - `torii.hdl.ast.Signal` properly checks that `name` is valid.
+  - `torii.hdl.ast.ClockSignal` and `torii.hdl.ast.ResetSignal` properly check that the clock domain name is valid.
+  - `torii.hdl.ast.Property` now properly checks that `name` is valid.
+  - `torii.hdl.cd.ClockDomain` now properly checks that `name` is valid in it's constructor and `rename` method.
+  - `torii.hdl.dsl.Module.FSM` now properly checks that `name` and `domain` are valid.
+  - `torii.hdl.dsl.Module` now properly validates the name of of submodules when added.
+  - `torii.hdl.ir.Fragment` now properly checks that `domain` is valid in `add_driver` and that `name` is valid in `add_subfragment`.
+  - `torii.hdl.ir.Instance` now properly checks that the instance type is valid as well as the the names of the `kwargs`.
+  - `torii.hdl.mem.Memory` now properly checks that `name` is valid.
+  - `torii.hdl.mem.ReadPort`, `torii.hdl.mem.WritePort`, and `torii.hdl.mem.DummyPort` all now properly check that `domain` is valid.
+  - `torii.hdl.mem.DummyPort` now properly checks that `name` is valid.
+  - `torii.hdl.rec.Layout` now properly checks that `name` is valid.
+  - `torii.hdl.rec.Record` now properly checks that `name` is valid in the constructor and `like` method.
+
 ## [0.8.1] - 2025-08-03
 
 ### Changed

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -5,7 +5,7 @@ from enum          import Enum, EnumMeta
 from sys           import version_info
 
 from torii.hdl.ast import (
-	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Part, Past, ResetSignal, Rose, Sample,
+	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Part, Past, Property, ResetSignal, Rose, Sample,
 	Shape, ShapeCastable, ShapeLike, Signal, Slice, Stable, Switch, Value, ValueCastable, ValueLike,
 	signed, unsigned,
 )
@@ -13,7 +13,6 @@ from torii.hdl.cd  import ClockDomain
 from torii.hdl.dsl import Module
 from torii.hdl.ir  import Elaboratable
 from torii.sim     import Delay, Simulator, Tick
-
 
 from ..utils       import ToriiTestSuiteCase
 
@@ -1324,6 +1323,28 @@ class SignalTestCase(ToriiTestSuiteCase):
 		s2 = Signal(name = 'sig')
 		self.assertEqual(s2.name, 'sig')
 
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(TypeError, r'^Name must be a string, not 1$'):
+			Signal(name = 1)
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Signal name must not be empty or contain any control or whitespace characters$'
+		):
+			Signal(name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Signal name must not be empty or contain any control or whitespace characters$'
+		):
+			Signal(name = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Signal name must not be empty or contain any control or whitespace characters$'
+		):
+			Signal(name = '\u0006')
+
 	def test_reset(self):
 		s1 = Signal(4, reset = 0b111, reset_less = True)
 		self.assertEqual(s1.reset, 0b111)
@@ -1487,6 +1508,25 @@ class ClockSignalTestCase(ToriiTestSuiteCase):
 		):
 			ClockSignal('comb')
 
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockSignal('')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockSignal(' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockSignal('\u0006')
+
 class ResetSignalTestCase(ToriiTestSuiteCase):
 	def test_domain(self):
 		s1 = ResetSignal()
@@ -1515,6 +1555,25 @@ class ResetSignalTestCase(ToriiTestSuiteCase):
 			r'^Domain \'comb\' does not have a reset$'
 		):
 			ResetSignal('comb')
+
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ResetSignal('')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ResetSignal(' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ResetSignal('\u0006')
 
 class MockValueCastable(ValueCastable):
 	def __init__(self, dest) -> None:
@@ -1972,6 +2031,25 @@ class SampleTestCase(ToriiTestSuiteCase):
 		with sim.write_vcd('test.vcd'):
 			sim.run()
 
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Sample domain name must not be empty or contain any control or whitespace characters$'
+		):
+			Sample(Signal(), 1, domain = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Sample domain name must not be empty or contain any control or whitespace characters$'
+		):
+			Sample(Signal(), 1, domain = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Sample domain name must not be empty or contain any control or whitespace characters$'
+		):
+			Sample(Signal(), 1, domain = '\x15')
+
 class InitialTestCase(ToriiTestSuiteCase):
 	def test_initial(self):
 		i = Initial()
@@ -2012,3 +2090,26 @@ class SwitchTestCase(ToriiTestSuiteCase):
 	def test_two_cases(self):
 		s = Switch(Const(0, 8), {('00001111', 123): []})
 		self.assertEqual(s.cases, {('00001111', '01111011'): []})
+
+class PropertyTestCase(ToriiTestSuiteCase):
+
+	def test_name_wrong(self):
+		Property._MustUse__silence = True
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Property name must not be empty or contain any control or whitespace characters$'
+		):
+			Property('assert', Signal(), name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Property name must not be empty or contain any control or whitespace characters$'
+		):
+			Property('assert', Signal(), name = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Property name must not be empty or contain any control or whitespace characters$'
+		):
+			Property('assert', Signal(), name = '\x18')

--- a/tests/hdl/test_cd.py
+++ b/tests/hdl/test_cd.py
@@ -27,6 +27,44 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 		cd_reset = ClockDomain(local = True)
 		self.assertEqual(cd_reset.local, True)
 
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain('')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain(' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain('\x14')
+
+	def test_rename_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain('meow').rename('')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain('meow').rename(' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+		):
+			ClockDomain('meow').rename('\x7F')
+
 	def test_edge(self):
 		sync = ClockDomain()
 		self.assertEqual(sync.clk_edge, 'pos')

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -750,6 +750,51 @@ class DSLTestCase(ToriiTestSuiteCase):
 			with m.FSM(domain = 'comb'):
 				pass # :nocov:
 
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM domain must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(domain = ''):
+				pass # :nocov:
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM domain must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(domain = ' '):
+				pass # :nocov:
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM domain must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(domain = '\r'):
+				pass # :nocov:
+
+	def test_FSM_name_wrong(self):
+		m = Module()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM name must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(name = ''):
+				pass # :nocov:
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM name must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(name = ' '):
+				pass # :nocov:
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^FSM name must not be empty or contain any control or whitespace characters$'
+		):
+			with m.FSM(name = '\r'):
+				pass # :nocov:
+
 	def test_FSM_wrong_undefined(self):
 		m = Module()
 		with self.assertRaisesRegex(
@@ -866,6 +911,28 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m1.submodules['foo'] = m2
 		self.assertEqual(m1._anon_submodules, [])
 		self.assertEqual(m1._named_submodules, {'foo': m2})
+
+	def test_submodule_name_wrong(self):
+		m = Module()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^A submodule name must not be empty if provided, to add an anonymous submodule either'
+			r' omit the `name` parameter or explicitly set it to `None`$'
+		):
+			m.submodules[''] = Module()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Submodule name must not contain any control or whitespace characters$'
+		):
+			m.submodules['\t'] = Module()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Submodule name must not contain any control or whitespace characters$'
+		):
+			m.submodules['\0'] = Module()
 
 	def test_submodule_wrong(self):
 		m = Module()

--- a/tests/hdl/test_ir.py
+++ b/tests/hdl/test_ir.py
@@ -71,6 +71,27 @@ class FragmentGeneratedTestCase(ToriiTestSuiteCase):
 		):
 			f1.find_subfragment('fx')
 
+	def test_subfragment_name_wrong(self):
+		f1 = Fragment()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Subfragment name must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_subfragment(Fragment(), '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Subfragment name must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_subfragment(Fragment(), ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Subfragment name must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_subfragment(Fragment(), '\u000C')
+
 	def test_find_generated(self):
 		f1 = Fragment()
 		f2 = Fragment()
@@ -588,6 +609,28 @@ class FragmentDomainsTestCase(ToriiTestSuiteCase):
 		):
 			f1._propagate_domains(missing_domain = lambda name: f2)
 
+	def test_domain_name_wrong(self):
+		f1 = Fragment()
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Domain must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_driver(Signal(), '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Domain must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_driver(Signal(), '\t')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Domain must not be empty or contain any control or whitespace characters$'
+		):
+			f1.add_driver(Signal(), '\u2069')
+
+
 class FragmentHierarchyConflictTestCase(ToriiTestSuiteCase):
 	def setUp_self_sub(self):
 		self.s1 = Signal()
@@ -810,6 +853,25 @@ class InstanceTestCase(ToriiTestSuiteCase):
 		):
 			Instance('foo', x_s1 = s)
 
+	def test_instance_type_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Instance type must not be empty or contain any control or whitespace characters$'
+		):
+			Instance('', a_NYA = 'meow')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Instance type must not be empty or contain any control or whitespace characters$'
+		):
+			Instance('\t', a_NYA = 'meow')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Instance type must not be empty or contain any control or whitespace characters$'
+		):
+			Instance('\u0085', a_NYA = 'meow')
+
 	def setUp_cpu(self):
 		self.rst = Signal()
 		self.stb = Signal()
@@ -944,6 +1006,21 @@ class InstanceTestCase(ToriiTestSuiteCase):
 			f: ('top',),
 			a_f: ('top', 'a$U$0')
 		})
+
+	def test_instance_kwargs_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Instance parameter must not contain any control or whitespace characters$'
+		):
+			params = { 'a_\tNYA': 'MEOW' }
+			Instance('NYA', **params)
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Instance parameter must not contain any control or whitespace characters$'
+		):
+			params = { 'a_N\u202AYA': 'MEOW' }
+			Instance('NYA', **params)
 
 class ElaboratableTestCase(ToriiTestSuiteCase):
 	def test_formal_on_nonformal_elaboratable(self):

--- a/tests/hdl/test_mem.py
+++ b/tests/hdl/test_mem.py
@@ -15,6 +15,25 @@ class MemoryTestCase(ToriiTestSuiteCase):
 		m3 = Memory(width = 8, depth = 4, name = 'foo')
 		self.assertEqual(m3.name, 'foo')
 
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Memory name must not be empty or contain any control or whitespace characters$'
+		):
+			Memory(width = 8, depth = 4, name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Memory name must not be empty or contain any control or whitespace characters$'
+		):
+			Memory(width = 8, depth = 4, name = '\t')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Memory name must not be empty or contain any control or whitespace characters$'
+		):
+			Memory(width = 8, depth = 4, name = '\u061C')
+
 	def test_geometry(self):
 		m = Memory(width = 8, depth = 4)
 		self.assertEqual(m.width, 8)
@@ -98,6 +117,27 @@ class MemoryTestCase(ToriiTestSuiteCase):
 		):
 			mem.read_port(domain = 'comb', transparent = False)
 
+	def test_read_port_domain_wrong_empty(self):
+		mem = Memory(width = 8, depth = 4)
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^ReadPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.read_port(domain = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^ReadPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.read_port(domain = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^ReadPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.read_port(domain = '\u202E')
+
 	def test_write_port(self):
 		mem    = Memory(width = 8, depth = 4)
 		wrport = mem.write_port()
@@ -136,6 +176,27 @@ class MemoryTestCase(ToriiTestSuiteCase):
 		):
 			mem.write_port(granularity = 3)
 
+	def test_write_port_domain_wrong_empty(self):
+		mem = Memory(width = 8, depth = 4)
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^WritePort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.write_port(domain = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^WritePort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.write_port(domain = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^WritePort domain must not be empty or contain any control or whitespace characters$'
+		):
+			mem.write_port(domain = '\u202E')
+
 class DummyPortTestCase(ToriiTestSuiteCase):
 	def test_name(self):
 		p1 = DummyPort(data_width = 8, addr_width = 2)
@@ -144,6 +205,44 @@ class DummyPortTestCase(ToriiTestSuiteCase):
 		self.assertEqual(p2.addr.name, 'dummy_addr')
 		p3 = DummyPort(data_width = 8, addr_width = 2, name = 'foo')
 		self.assertEqual(p3.addr.name, 'foo_addr')
+
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort name must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort name must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, name = ' ')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort name must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, name = '\u200C')
+
+	def test_domain_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, domain = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, domain = '\v')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^DummyPort domain must not be empty or contain any control or whitespace characters$'
+		):
+			DummyPort(data_width = 8, addr_width = 4, domain = '\u200D')
 
 	def test_sizes(self):
 		p1 = DummyPort(data_width = 8, addr_width = 2)

--- a/tests/hdl/test_rec.py
+++ b/tests/hdl/test_rec.py
@@ -92,6 +92,24 @@ class LayoutTestCase(ToriiTestSuiteCase):
 		):
 			Layout.cast([(1, 1)])
 
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Field name must not be empty or contain any control or whitespace characters$'
+		):
+			Layout.cast([('', 1)])
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Field name must not be empty or contain any control or whitespace characters$'
+		):
+			Layout.cast([('\a', 1)])
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Field name must not be empty or contain any control or whitespace characters$'
+		):
+			Layout.cast([('\n', 1)])
+
 	def test_wrong_name_duplicate(self):
 		with self.assertRaisesRegex(
 			NameError,
@@ -211,6 +229,27 @@ class RecordTestCase(ToriiTestSuiteCase):
 		self.assertEqual(r3.name, 'foo')
 		r4 = Record.like(r1, name_suffix = 'foo')
 		self.assertEqual(r4.name, 'r1foo')
+
+	def test_like_name_wrong(self):
+		r1 = Record([('a', 1), ('b', 2)])
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record.like(r1, name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record.like(r1, name = '\0')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record.like(r1, name = '\v')
 
 	def test_like_modifications(self):
 		r1 = Record([('a', 1), ('b', [('s', 1)])])
@@ -390,6 +429,25 @@ class RecordTestCase(ToriiTestSuiteCase):
 			repr(ulpi_int),
 			'(rec ulpi_int (rec ulpi_int__data i o oe) nxt stp (rec ulpi_int__dir i) rst)'
 		)
+
+	def test_name_wrong(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record([('nya', 1)], name = '')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record([('nya', 1)], name = '\0')
+
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Record name must not be empty or contain any control or whitespace characters$'
+		):
+			Record([('nya', 1)], name = '\v')
 
 class ConnectTestCase(ToriiTestSuiteCase):
 	def setUp_flat(self):

--- a/tests/sim/regression_harness.py
+++ b/tests/sim/regression_harness.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-import os
-
 from torii.hdl.ast   import Cat, Const, Signal
 from torii.hdl.cd    import ClockDomain
 from torii.hdl.dsl   import Module
@@ -21,20 +19,6 @@ class SimulatorRegressionTestMixin(SimulatorRegressionTestMixinBase):
 			self.assertEqual((yield -(Const(0b11, 2).as_signed())), 1)
 		sim.add_process(process)
 		sim.run()
-
-	def test_bug_595(self):
-		dut = Module()
-		with dut.FSM(name = 'name with space'):
-			with dut.State(0):
-				pass
-		sim = self.get_simulator(dut)
-		with self.assertRaisesRegex(
-			NameError,
-			r'^Signal \'bench\.top\.name with space_state\' contains a whitespace character$'
-		):
-			with open(os.path.devnull, 'w') as f:
-				with sim.write_vcd(f):
-					sim.run() # :nocov:
 
 	def test_bug_588(self):
 		dut = Module()

--- a/torii/hdl/cd.py
+++ b/torii/hdl/cd.py
@@ -3,7 +3,7 @@
 from typing        import Literal
 
 from ..diagnostics import NameNotFound
-from ..util        import tracer
+from ..util        import _check_name, tracer
 from .ast          import Signal
 
 __all__ = (
@@ -62,6 +62,10 @@ class ClockDomain:
 				name = tracer.get_var_name()
 			except NameNotFound:
 				raise ValueError('Clock domain name must be specified explicitly')
+
+		if name == '' or not _check_name(name):
+			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+
 		if name.startswith('cd_'):
 			name = name[3:]
 		if name == 'comb':
@@ -85,6 +89,9 @@ class ClockDomain:
 		self.local = local
 
 	def rename(self, new_name: str) -> None:
+		if new_name == '' or not _check_name(new_name):
+			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+
 		self.name = new_name
 		self.clk.name = self._name_for(new_name, 'clk')
 		if self.rst is not None:

--- a/torii/hdl/rec.py
+++ b/torii/hdl/rec.py
@@ -9,7 +9,7 @@ from functools       import reduce, wraps
 from inspect         import get_annotations, isclass
 from typing          import Any, TypeAlias, get_args, get_origin
 
-from ..util          import tracer, union
+from ..util          import _check_name, tracer, union
 from .ast            import Cat, Shape, ShapeCastT, Signal, SignalSet, Value, ValueCastable
 
 __all__ = (
@@ -58,6 +58,8 @@ class Layout:
 					)
 			if not isinstance(name, str):
 				raise TypeError(f'Field {field!r} has invalid name: should be a string')
+			if name == '' or not _check_name(name):
+				raise NameError('Field name must not be empty or contain any control or whitespace characters')
 			if not isinstance(shape, Layout):
 				try:
 					# Check provided shape by calling Shape.cast and checking for exception
@@ -114,6 +116,9 @@ class Record(ValueCastable):
 		else:
 			new_name = tracer.get_var_name(depth = 2 + src_loc_at, default = None)
 
+		if new_name == '' or not _check_name(new_name):
+			raise NameError('Record name must not be empty or contain any control or whitespace characters')
+
 		def concat(a: str | None, b: str) -> str:
 			if a is None:
 				return b
@@ -165,6 +170,9 @@ class Record(ValueCastable):
 	) -> None:
 		if name is None:
 			name = tracer.get_var_name(depth = 2 + src_loc_at, default = None)
+		else:
+			if name == '' or not _check_name(name):
+				raise NameError('Record name must not be empty or contain any control or whitespace characters')
 
 		self.name    = name
 		self.src_loc = tracer.get_src_loc(src_loc_at)

--- a/torii/util/__init__.py
+++ b/torii/util/__init__.py
@@ -6,6 +6,7 @@ from linecache       import getlines
 from operator        import ior
 from re              import Match, compile
 from typing          import TypeAlias, TypeVar
+from unicodedata     import category
 
 __all__ = (
 	'flatten',
@@ -191,3 +192,26 @@ def get_linter_option(
 			return default
 
 	return default
+
+def _check_name(name: str) -> bool:
+	'''
+	Validate that a name that will be emitted to RTLIL is valid by checking for
+	any whitespace or control characters.
+
+	Warning
+	----
+	This does not to full name validation, it only checks the rough Unicode category,
+	meaning it's possible for invalid characters to leak through.
+
+	Parameters
+	----------
+	name: str
+		The name to check.
+
+	Returns
+	-------
+	bool
+		True if the name is valid, otherwise False
+	'''
+
+	return not any(category(ch) in ('Cc', 'Cf', 'Cs', 'Co', 'Cn', 'Zs', 'Zl', 'Zp') for ch in name)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR fixes an issue where you could supply invalid names for HDL constructs that would result in broken RTLIL, as well as possibly unwanted and broken behaviour.

We now do a rough validation that names/domains don't contain any whitespace or control characters.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
