### PR TITLE
Add `torii.lib.cdc.PulseStretcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Unreleased template stuff
 - New `PCIBusResources` for 32-bit and 64-bit PCI busses.
 - New `platformdirs~=4.0` dependency used for platform correct cache, temp, and config directories.
 - Added a new `torii.util.directories` module for getting appropriate cross-platform directories for things such as cache and configuration directories.
+- Added `torii.lib.cdc.PulseStretcher` so smear one-cycle pulses over to multiple cycles.
 
 ### Changed
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds a simple pulse stretcher to `torii.lib.cdc` to stretch single cycle pulses out over to multiple cycles.

Currently it only operates within the same clock domain, but I couldn't find a better spot for it in the library.

It could be combined with the `PulseSynchronizer` on the input to stretch a pulse from a different clock domain, it might be eventually worth it to roll that functionality into `PulseStretcher` so that if the in and out domains are different then it will internally create a `PulseSynchronizer` and do the stretching on the output domain.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
