### PR TITLE
Feature: Add (limited) initial GW5A support to GowinPlatform

### DIFF
--- a/torii/platform/vendor/gowin.py
+++ b/torii/platform/vendor/gowin.py
@@ -58,11 +58,11 @@ class GowinPlatform(TemplatedPlatform):
 
 	def parse_part(self):
 		# These regular expressions match all >900 parts of Gowin device_info.csv
-		reg_series    = r'(GW[12]{1}[AN]{1}[EFNRSZ]{0,3})-'
+		reg_series    = r'(GW[125]{1}[AN]{1}[EFNRSZ]{0,3})-'
 		reg_voltage   = r'(ZV|EV|LV|LX|UV|UX)'
-		reg_size      = r'(1|2|4|9|18|55)'
-		reg_subseries = r'(?:(B|C|S|X|P5)?)'
-		reg_package   = r'((?:PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X)?)'
+		reg_size      = r'(1|2|4|9|18|25|55)'
+		reg_subseries = r'(?:(B|C|S|X|P5|A)?)'
+		reg_package   = r'((?:PG|UG|EQ|LQ|MG|M|QN|CS|FN)(?:\d+)(?:P?)(?:A|E|M|CF|C|D|G|H|F|S|T|U|X|N)?)'
 		reg_speed     = r'((?:C\d{1}/I\d{1})|ES|A\d{1}|I\d{1})'
 
 		match = re.match(
@@ -147,7 +147,8 @@ class GowinPlatform(TemplatedPlatform):
 		'GW2AN-9X': 'OSCW',
 		'GW2ANR-18C': 'OSC',
 		'GW2AR-18': 'OSC',
-		'GW2AR-18C': 'OSC'
+		'GW2AR-18C': 'OSC',
+		'GW5A-25A': 'OSCA',
 	}
 
 	@property


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This is the start of GW5A (eg: Tang Primer 25k) support in GowinPlatform when using the "Gowin" toolchain (GW5A is still a work-in-progress in Apicula).

These changes are necessary to enable creation of a torii-boards definition for boards that use the GW5A-25A. Added under family 'GW5A-25A' as it's the only GW5A family defined in [Apicula chipdb.py](https://github.com/YosysHQ/apicula/blob/1fc625a75b1915005f09212a724985817677e8a1/apycula/chipdb.py#L475) at this time, though my own board's GW5A-LV25MG121NC1/I0 chip is not yet supported in Apicula.

There should not be any side-effects to this change, though there is not currently any handling for the Apicula cases. While the existing GowinPlatform file command templates make reference to `nextpnr-gowin` this will probably need to be changed to `nextpnr-himbaechel` for everything to work when GW5A-25A support is functioning in Apicula (it probably already needs a *possibly breaking* change as nextpnr-gowin doesn't seem to be a thing in the nextpnr package anymore, but that's for another PR).

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

## Relevant Issues/Pull Requests/Discussions

- needed by https://github.com/shrine-maiden-heavy-industries/torii-boards/pull/11

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
