### PR TITLE
Fix `torii.platform.resources.user`'s Split Resources

### DIFF
--- a/tests/platform/resources/test_resources.py
+++ b/tests/platform/resources/test_resources.py
@@ -16,6 +16,36 @@ class ResourcesTestCase(ToriiTestCase):
 			self.assertEqual(res.name, 'test')
 			self.assertEqual(res.number, idx)
 
+	def test_split_resources_named(self):
+		resources = _SplitResources('test', pins = 'A B C D E', default_name = 'foo', dir = 'io')
+
+		self.assertEqual(len(resources), 5)
+
+		for idx, res in enumerate(resources):
+			self.assertEqual(len(res.ios), 1)
+			self.assertEqual(res.name, 'test')
+			self.assertEqual(res.number, idx)
+
+	def test_split_resources_numbered(self):
+		resources = _SplitResources(5, pins = 'A B C D E', default_name = 'test', dir = 'io')
+
+		self.assertEqual(len(resources), 5)
+
+		for idx, res in enumerate(resources, start = 5):
+			self.assertEqual(len(res.ios), 1)
+			self.assertEqual(res.name, 'test')
+			self.assertEqual(res.number, idx)
+
+	def test_split_resources_named_and_numbered(self):
+		resources = _SplitResources('test', 5, pins = 'A B C D E', default_name = 'foo', dir = 'io')
+
+		self.assertEqual(len(resources), 5)
+
+		for idx, res in enumerate(resources, start = 5):
+			self.assertEqual(len(res.ios), 1)
+			self.assertEqual(res.name, 'test')
+			self.assertEqual(res.number, idx)
+
 	def test_led_resources(self):
 		leds = LEDResources(pins = 'A B C D E F', attrs = Attrs(IO_TYPE = 'LVCMOS33'))
 

--- a/torii/platform/resources/user.py
+++ b/torii/platform/resources/user.py
@@ -11,13 +11,54 @@ __all__ = (
 )
 
 def _SplitResources(
-	name_or_number: str | int | None = None, number: int | None = None, *,
-	default_name: str, dir: IODirectionIO, pins: str | list[str] | dict[int, str], invert: bool = False,
-	conn: ResourceConn | None = None,
+	name_or_number: str | int | None = None, number: int | None = None, *, default_name: str, dir: IODirectionIO,
+	pins: str | list[str] | dict[int, str], invert: bool = False, conn: ResourceConn | None = None,
 	attrs: Attrs | None = None,
 ) -> list[Resource]:
 	'''
-	.. todo:: Document Me
+	Create an array of simple named resources from a collection of pins.
+
+	Warning
+	-------
+	This is a Torii-internal API for splitting resources, if you are looking to split LEDs, Buttons,
+	or Switches, please use the appropriate resource methods for those, as their API is stable while
+	this API is **not**.
+
+	Parameters
+	----------
+	name_or_number: str | int | None
+		The common name for the split resources, or the explicit start index for the
+		resources.
+
+		If the name is not supplied the value in ``default_name`` will be used.
+
+	number: int | None
+		The explicit start index if ``name_or_number`` is the name of the resources.
+
+	default_name: str
+		The name all the resources will be under, for example `led`.
+
+	dir: IODirecitionIO
+		IO Direction for the resource pin.
+
+	pins: str | list[str] | dict[int, str]
+		The collection of pints to split into individual resources.
+
+	invert: bool
+		Invert the logic on the pin for the resource.
+
+	offset: int | None
+		The index offset to start resource splitting at.
+
+		This allows you to use multiple split resources in the same resource collection. This is useful
+		for things like ensure all LEDs have the same resource name, but can be split over IO bank voltages
+		or connectors.
+
+	conn: ResourceConn | None
+		The connector to use for the split resources if applicable.
+
+	attrs: Attrs | None
+		The attributes to apply to the split resources if applicable.
 	'''
 
 	if not isinstance(pins, (str, list, dict)):
@@ -32,12 +73,27 @@ def _SplitResources(
 
 	resources: list[Resource] = []
 
+	name: str | None = None
+	if isinstance(name_or_number, str):
+		name = name_or_number
+
+	if isinstance(name_or_number, int):
+		number = name_or_number
+
+	if number is None:
+		number = 0
+
 	for idx, pin in pins.items():  # type: ignore
 		ios: list[Pins | Attrs] = [ Pins(pin, dir = dir, invert = invert, conn = conn) ]
 		if attrs is not None:
 			ios.append(attrs)
 		# NOTE(aki): This is likely problematic, but
-		resources.append(Resource.family(idx, None, default_name = default_name, ios = ios))
+		res_index = idx + number
+		resources.append(Resource.family(
+			res_index if name is None else name,
+			res_index if name is not None else None,
+			default_name = default_name, ios = ios
+		))
 
 	return resources
 
@@ -47,7 +103,35 @@ def ButtonResources(
 	conn: ResourceConn | None = None, attrs: Attrs | None = None,
 ) -> list[Resource]:
 	'''
-	.. todo:: Document Me
+	Turn a list of pins connected to switches into individual button resources.
+
+	Parameters
+	----------
+	name_or_number: str | int | None
+		The common name for the button resources, or the explicit start index for the
+		resources.
+
+		If the name is not supplied, the resources will all have the common name of ``button``.
+
+	number: int | None
+		The explicit start index if ``name_or_number`` is the name of the button resources.
+
+	pins: str | list[str] | dict[int, str]
+		The pins for each button.
+
+	invert: bool
+		Invert the logic for the buttons.
+
+	conn: ResourceConn | None
+		The connector these buttons are on if applicable.
+
+	attrs: Attrs | None
+		The attributes to apply to the buttons if applicable.
+
+	Returns
+	-------
+	list[Resource]
+		The collection of expanded button resources.
 	'''
 
 	return _SplitResources(
@@ -61,7 +145,35 @@ def LEDResources(
 	conn: ResourceConn | None = None, attrs: Attrs | None = None,
 ) -> list[Resource]:
 	'''
-	.. todo:: Document Me
+	Turn a list of pins connected to switches into individual LED resources.
+
+	Parameters
+	----------
+	name_or_number: str | int | None
+		The common name for the LED resources, or the explicit start index for the
+		resources.
+
+		If the name is not supplied, the resources will all have the common name of ``led``.
+
+	number: int | None
+		The explicit start index if ``name_or_number`` is the name of the LED resources.
+
+	pins: str | list[str] | dict[int, str]
+		The pins for each LED.
+
+	invert: bool
+		Invert the logic for the LEDs.
+
+	conn: ResourceConn | None
+		The connector these LEDs are on if applicable.
+
+	attrs: Attrs | None
+		The attributes to apply to the LEDs if applicable.
+
+	Returns
+	-------
+	list[Resource]
+		The collection of expanded LED resources.
 	'''
 
 	return _SplitResources(
@@ -75,7 +187,43 @@ def RGBLEDResource(
 	conn: ResourceConn | None = None, attrs: Attrs | None = None
 ) -> Resource:
 	'''
-	.. todo:: Document Me
+	Create an RGB LED resource.
+
+	This can be either common cathode or common anode, you simply need to set ``invert`` as
+	appropriate.
+
+	Parameters
+	----------
+	name_or_number: str | int | None
+		The name of this resource, or the explicit number to assign this resource.
+
+		If no name is specified the default resource name of ``rgb_led`` is used.
+
+	number: int | None
+		The explicit number to assign this resource.
+
+	r: str
+		The LEDs red channel.
+
+	g: str
+		The LEDs green channel.
+
+	b: str
+		The LEDs blue channel.
+
+	invert: bool
+		Invert the logic for the buttons.
+
+	conn: ResourceConn | None
+		The connector these buttons are on if applicable.
+
+	attrs: Attrs | None
+		The attributes to apply to the buttons if applicable.
+
+	Returns
+	-------
+	Resource
+		The newly constructed RGB LED resource.
 	'''
 
 	ios: list[SubsigArgT] = []
@@ -95,7 +243,35 @@ def SwitchResources(
 	conn: ResourceConn | None = None, attrs: Attrs | None = None,
 ) -> list[Resource]:
 	'''
-	.. todo:: Document Me
+	Turn a list of pins connected to switches into individual switch resources.
+
+	Parameters
+	----------
+	name_or_number: str | int | None
+		The common name for the switch resources, or the explicit start index for the
+		resources.
+
+		If the name is not supplied, the resources will all have the common name of ``switch``.
+
+	number: int | None
+		The explicit start index if ``name_or_number`` is the name of the switch resources.
+
+	pins: str | list[str] | dict[int, str]
+		The pins for each switch.
+
+	invert: bool
+		Invert the logic for the switches.
+
+	conn: ResourceConn | None
+		The connector these switches are on if applicable.
+
+	attrs: Attrs | None
+		The attributes to apply to the switches if applicable.
+
+	Returns
+	-------
+	list[Resource]
+		The collection of expanded switch resources.
 	'''
 
 	return _SplitResources(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR fixes #106, where `name_or_number` and `number` params for the various split resources were ignored.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.


<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
