### PR TITLE
torii.build.dsl: Prevent Subsignal name collisions.

### DIFF
--- a/tests/build/test_dsl.py
+++ b/tests/build/test_dsl.py
@@ -295,6 +295,14 @@ class SubsignalTestCase(ToriiTestSuiteCase):
 		):
 			Subsignal('a', Pins('A0'), Clock(1e6), Clock(1e7))
 
+	def test_duplicated_names(self):
+		with self.assertRaisesRegex(
+			NameError,
+			r'^Attempted to add subsignal `\(subsignal bar \(pins io B\)\)` to `foo` but a subsignal with that'
+			r' name already exists.$'
+		):
+			Subsignal('foo', Subsignal('bar', Pins('A')), Subsignal('bar', Pins('B')))
+
 class ResourceTestCase(ToriiTestSuiteCase):
 	def test_basic(self):
 		r = Resource(

--- a/torii/build/dsl.py
+++ b/torii/build/dsl.py
@@ -238,6 +238,8 @@ class Subsignal:
 		self.attrs                 = Attrs()
 		self.clock: Clock | None   = None
 
+		_subsig_names = set[str]()
+
 		if not args:
 			raise ValueError('Missing I/O constraints')
 		for arg in args:
@@ -252,6 +254,13 @@ class Subsignal:
 
 			elif isinstance(arg, Subsignal):
 				if not self.ios or isinstance(self.ios[-1], Subsignal):
+					if arg.name in _subsig_names:
+						raise NameError(
+							f'Attempted to add subsignal `{arg!r}` to `{self.name}` but a subsignal with that name'
+							' already exists.'
+						)
+
+					_subsig_names.add(arg.name)
 					self.ios.append(arg)
 				else:
 					raise TypeError(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR fixes #86 which is the case where `torii.build.dsl.Subsignal` would allow you to add any number of child `Subsignal`'s that have the same name as each other, causing eventual name collisions when generating constraints and cause problems in general with legalizing the netlist.

This is done by simply checking for `set` membership when adding IOs in the `Subsignal` constructor. If the name of child `Subsignal` we want to add is already in the set, we throw a `NameError`, otherwise we add the child and its name to the set. This set is not persisted within the `Subsignal`.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
