### PR TITLE
Fix: Simple stream generator StreamSerializer start condition

### DIFF
--- a/torii/lib/stream/simple/generator.py
+++ b/torii/lib/stream/simple/generator.py
@@ -339,7 +339,7 @@ class StreamSerializer(Generic[T], Elaboratable):
 			with m.State('IDLE'):
 				m.d.sync += [ stream_pos.eq(0), ]
 
-				with m.If(self.start & (self.max_length > 1)):
+				with m.If(self.start & (self.max_length > 0)):
 					m.next = 'STREAMING'
 
 			with m.State('STREAMING'):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

In this PR we fix a bug we hit when updating Torii-USB to use torii.lib.stream.simple.generator.StreamSerializer - the start condition comparison this replaces means no single data unit request could ever be fulfilled as it could never start by transitioning into the STREAMING state. With this corrected, everything works as before with Torii-USB's version of this class.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

## Relevant Issues/Pull Requests/Discussions

<!--
	Delete this comment and ink to any relevant issues, pull requests, or discussions here,
	if there are no relevant issues, pull requests, or discussions, then delete this comment
	and the heading above.

	Some examples:

		If it fixes an issue:

			- fixes #XXXX

		If it depends on another PR:

			- needs #XXXX

		If it references a discussion:

			- [discussions/XXXXX](https://github.com/shrine-maiden-heavy-industries/torii-hdl/discussions/XXXXX)
-->

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
