### PR TITLE
Tentatively add `ty` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           nox -s typecheck-mypy
           nox -s typecheck-pyright
+          nox -s typecheck-ty
 
   test-torii:
     runs-on: ubuntu-latest

--- a/noxfile.py
+++ b/noxfile.py
@@ -227,6 +227,18 @@ def typecheck_pyright(session: Session) -> None:
 	with (OUTPUT_DIR / 'pyright.log').open('w') as f:
 		session.run('pyright', *session.posargs, stdout = f)
 
+@nox.session(name = 'typecheck-ty', reuse_venv = True)
+def typecheck_ty(session: Session) -> None:
+	OUTPUT_DIR = BUILD_DIR / 'typing' / 'pyright'
+	OUTPUT_DIR.mkdir(parents = True, exist_ok = True)
+
+	session.install('ty')
+	session.install('types-Pygments', 'types-setuptools')
+	session.install('-e', '.')
+
+	with (OUTPUT_DIR / 'ty.log').open('w') as f:
+		session.run('ty', 'check', *session.posargs, stdout = f)
+
 @nox.session(reuse_venv = True)
 def lint(session: Session) -> None:
 	session.install('flake8')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,3 +195,6 @@ multiline-quotes = 'single'
 
 [tool.ruff.lint.isort]
 lines-after-imports = 1
+
+[tool.ty.rules]
+unused-ignore-comment = 'warn'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

[`ty`](https://docs.astral.sh/ty/) is a new python type checker/lang server by astral who are doing [`uv`](https://docs.astral.sh/uv) and [`ruff`](https://docs.astral.sh/ruff/) as well, and I figured having experimental support would be fine even though it's still in beta.

It might also be something to look into to replace Pylance for VSCode users too.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.


<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
