### PR TITLE
Improve Resource and Platform diagnostics

### DIFF
--- a/tests/build/test_dsl.py
+++ b/tests/build/test_dsl.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import warnings
-from collections     import OrderedDict
+from collections       import OrderedDict
 
-from torii.build.dsl import (
+from torii.build.dsl   import (
 	Attrs, Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Resource, Subsignal,
 )
-from torii.hdl.time  import Period, Frequency, MHz
+from torii.diagnostics import ToriiSyntaxError
+from torii.hdl.time    import Period, Frequency, MHz
 
-from ..utils         import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
 class PinsTestCase(ToriiTestSuiteCase):
 	def test_basic(self):
@@ -53,23 +54,25 @@ class PinsTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_names(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Names must be a whitespace-separated string, not \[\'A0\', \'A1\', \'A2\'\]$'
+			ToriiSyntaxError,
+			r'^Names must be a whitespace-separated string, not \[\'A0\', \'A1\', \'A2\'\]'
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			Pins(['A0', 'A1', 'A2'])
 
 	def test_wrong_dir(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Direction must be one of \'i\', \'o\', \'oe\', or \'io\', not \'wrong\'$'
+			ToriiSyntaxError,
+			r'^Direction must be one of \'i\', \'o\', \'oe\', or \'io\', not \'wrong\''
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			Pins('A0 A1', dir = 'wrong')
 
 	def test_wrong_conn(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Connector must be None or a pair of string \(connector name\) and '
-				r'integer\/string \(connector number\), not \(\'foo\', None\)$'
+				r'integer\/string \(connector number\), not \(\'foo\', None\) \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Pins('A0 A1', conn = ('foo', None))
@@ -80,17 +83,17 @@ class PinsTestCase(ToriiTestSuiteCase):
 			'pmod_0:0': 'A0',
 		}
 		with self.assertRaisesRegex(
-			NameError, (
+			ToriiSyntaxError, (
 				r'^Resource \(pins io pmod_0:0 pmod_0:1 pmod_0:2\) refers to nonexistent '
-				r'connector pin pmod_0:1$'
+				r'connector pin pmod_0:1 \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			p.map_names(mapping, p)
 
 	def test_wrong_assert_width(self):
 		with self.assertRaisesRegex(
-			AssertionError,
-			r'^3 names are specified \(0 1 2\), but 4 names are expected$'
+			ToriiSyntaxError,
+			r'^3 pin\(s\) are specified \(0 1 2\), but 4 pin\(s\) are expected \(test_dsl\.py, line \d+\)$'
 		):
 			Pins('0 1 2', assert_width = 4)
 
@@ -130,17 +133,17 @@ class DiffPairsTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_width(self):
 		with self.assertRaisesRegex(
-			TypeError, (
-				r'^Positive and negative pins must have the same width, but \(pins io A0\) '
-				r'and \(pins io B0 B1\) do not$'
+			ToriiSyntaxError, (
+				r'^Differential pairs must have a symmetric set of positive and negative pins, however '
+				r'fewer positive than negative pins were specified \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			DiffPairs('A0', 'B0 B1')
 
 	def test_wrong_assert_width(self):
 		with self.assertRaisesRegex(
-			AssertionError,
-			r'^3 names are specified \(0 1 2\), but 4 names are expected$'
+			ToriiSyntaxError,
+			r'^3 pin\(s\) are specified \(0 1 2\), but 4 pin\(s\) are expected \(test_dsl\.py, line \d+\)$'
 		):
 			DiffPairs('0 1 2', '3 4 5', assert_width = 4)
 
@@ -165,8 +168,8 @@ class AttrsTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_value(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Value of attribute FOO must be None, int, str, or callable, not 1\.0$'
+			ToriiSyntaxError,
+			r'^Value of attribute FOO must be None, int, str, or callable, not 1\.0 \(test_dsl\.py, line \d+\)$'
 		):
 			Attrs(FOO = 1.0)
 
@@ -255,66 +258,70 @@ class SubsignalTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s.clock.frequency, Frequency(1e6))
 
 	def test_wrong_empty_io(self):
-		with self.assertRaisesRegex(ValueError, r'^Missing I\/O constraints$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError, r'^Missing I\/O constraints \(test_dsl\.py, line \d+\)$'
+		):
 			Subsignal('a')
 
 	def test_wrong_io(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Constraint must be one of Pins, DiffPairs, Subsignal, Attrs, or Clock, '
-				r'not \'wrong\'$'
+				r'not \'wrong\' \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Subsignal('a', 'wrong')
 
 	def test_wrong_pins(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Pins and DiffPairs are incompatible with other location or subsignal '
-				r'constraints, but \(pins io A1\) appears after \(pins io A0\)$'
+				r'constraints, but \(pins io A1\) appears after \(pins io A0\) \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Subsignal('a', Pins('A0'), Pins('A1'))
 
 	def test_wrong_diffpairs(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Pins and DiffPairs are incompatible with other location or subsignal '
-				r'constraints, but \(pins io A1\) appears after \(diffpairs io \(p A0\) \(n B0\)\)$'
+				r'constraints, but \(pins io A1\) appears after \(diffpairs io \(p A0\) \(n B0\)\)'
+				r' \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Subsignal('a', DiffPairs('A0', 'B0'), Pins('A1'))
 
 	def test_wrong_subsignals(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Pins and DiffPairs are incompatible with other location or subsignal '
-				r'constraints, but \(pins io B0\) appears after \(subsignal b \(pins io A0\)\)$'
+				r'constraints, but \(pins io B0\) appears after \(subsignal b \(pins io A0\)\)'
+				r' \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Subsignal('a', Subsignal('b', Pins('A0')), Pins('B0'))
 
 	def test_wrong_clock(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Clock constraint can only be applied to Pins or DiffPairs, not '
-				r'\(subsignal b \(pins io A0\)\)$'
+				r'\(subsignal b \(pins io A0\)\) \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Subsignal('a', Subsignal('b', Pins('A0')), Clock(1 * MHz))
 
 	def test_wrong_clock_many(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Clock constraint can be applied only once$'
+			ToriiSyntaxError,
+			r'^Clock constraint can be applied only once \(test_dsl\.py, line \d+\)$'
 		):
 			Subsignal('a', Pins('A0'), Clock(1 * MHz), Clock(10 * MHz))
 
 	def test_duplicated_names(self):
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Attempted to add subsignal `\(subsignal bar \(pins io B\)\)` to `foo` but a subsignal with that'
-			r' name already exists.$'
+			ToriiSyntaxError,
+			r'^Attempted to add subsignal `bar` to `foo` but a subsignal with that'
+			r' name already exists\. \(test_dsl\.py, line \d+\)$'
 		):
 			Subsignal('foo', Subsignal('bar', Pins('A')), Subsignal('bar', Pins('B')))
 
@@ -336,8 +343,8 @@ class ResourceTestCase(ToriiTestSuiteCase):
 
 	def test_number_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Resource number must be an integer, not \(pins o 1\)$'
+			ToriiSyntaxError,
+			r'^Resource number must be an integer, not \(pins o 1\) \(test_dsl\.py, line \d+\)$'
 		):
 			# number omitted by accident
 			Resource('led', Pins('1', dir = 'o'))
@@ -416,28 +423,28 @@ class ConnectorTestCase(ToriiTestSuiteCase):
 
 	def test_conn_wrong_name(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Connector must be None or a pair of string \(connector name\) and '
-				r'integer\/string \(connector number\), not \(\'foo\', None\)$'
+				r'integer\/string \(connector number\), not \(\'foo\', None\) \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			Connector('ext', 'A', '0 1 2', conn = ('foo', None))
 
 	def test_wrong_io(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Connector I\/Os must be a dictionary or a string, not \[\]$'
+			ToriiSyntaxError,
+			r'^Connector I\/Os must be a dictionary or a string, not \[\] \(test_dsl\.py, line \d+\)$'
 		):
 			Connector('pmod', 0, [])
 
 	def test_wrong_dict_key_value(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Connector pin name must be a string, not 0$'
+			ToriiSyntaxError,
+			r'^Connector pin name must be a string, not 0 \(test_dsl\.py, line \d+\)$'
 		):
 			Connector('pmod', 0, {0: 'A'})
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Platform pin name must be a string, not 0$'
+			ToriiSyntaxError,
+			r'^Platform pin name must be a string, not 0 \(test_dsl\.py, line \d+\)$'
 		):
 			Connector('pmod', 0, {'A': 0})

--- a/tests/build/test_plat.py
+++ b/tests/build/test_plat.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build.plat import Platform
+from torii.build.plat  import Platform
+from torii.diagnostics import ToriiError
 
-from ..utils          import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
 class MockPlatform(Platform):
 	resources  = []
@@ -37,21 +38,21 @@ class PlatformTestCase(ToriiTestSuiteCase):
 
 	def test_add_file_wrong_filename(self):
 		with self.assertRaisesRegex(
-			TypeError,
+			ToriiError,
 			r'^File name must be a string, not 1$'
 		):
 			self.platform.add_file(1, '')
 
 	def test_add_file_wrong_contents(self):
 		with self.assertRaisesRegex(
-			TypeError,
+			ToriiError,
 			r'^File contents must be str, bytes, or a file-like object, not 1$'
 		):
 			self.platform.add_file('foo', 1)
 
 	def test_add_file_wrong_duplicate(self):
 		self.platform.add_file('foo', '')
-		with self.assertRaisesRegex(ValueError, r'^File \'foo\' already exists$'):
+		with self.assertRaisesRegex(ToriiError, r'^File \'foo\' already exists$'):
 			self.platform.add_file('foo', 'bar')
 
 	def test_iter_files(self):

--- a/tests/build/test_res.py
+++ b/tests/build/test_res.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.build.dsl import Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Subsignal
-from torii.build.res import Resource, ResourceError, ResourceManager
-from torii.hdl.ast   import Signal
-from torii.hdl.rec   import Record
-from torii.hdl.time  import Frequency, MHz, kHz
-from torii.lib.io    import Pin
+from torii.build.dsl   import Clock, Connector, DiffPairs, DiffPairsN, Pins, PinsN, Subsignal
+from torii.build.res   import Resource, ResourceManager
+from torii.diagnostics import ConstraintError, ResourceError, ToriiSyntaxError
+from torii.hdl.ast     import Signal
+from torii.hdl.rec     import Record
+from torii.hdl.time    import Frequency, MHz, kHz
+from torii.lib.io      import Pin
 
-from ..utils         import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
 class ResourceManagerTestCase(ToriiTestSuiteCase):
 	def setUp(self):
@@ -233,27 +234,33 @@ class ResourceManagerTestCase(ToriiTestSuiteCase):
 		])
 
 	def test_wrong_resources(self):
-		with self.assertRaisesRegex(TypeError, r'^Object \'wrong\' is not a Resource$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Object \'wrong\' is not a Resource \(test_res\.py, line \d+\)$'
+		):
 			self.cm.add_resources(['wrong'])
 
 	def test_wrong_resources_duplicate(self):
 		with self.assertRaisesRegex(
-			NameError, (
-				r'^Trying to add \(resource user_led 0 \(pins o A1\)\), but '
-				r'\(resource user_led 0 \(pins o A0\)\) has the same name and number$'
+			ResourceError, (
+				r'^Trying to add the resource user_led#0, but there is a previously added resource that has the same '
+				r'name and number$'
 			)
 		):
 			self.cm.add_resources([Resource('user_led', 0, Pins('A1', dir = 'o'))])
 
 	def test_wrong_connectors(self):
-		with self.assertRaisesRegex(TypeError, r'^Object \'wrong\' is not a Connector$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Object \'wrong\' is not a Connector \(test_res\.py, line \d+\)$'
+		):
 			self.cm.add_connectors(['wrong'])
 
 	def test_wrong_connectors_duplicate(self):
 		with self.assertRaisesRegex(
-			NameError, (
-				r'^Trying to add \(connector pmod 0 1=>1 2=>2\), but '
-				r'\(connector pmod 0 1=>B0 2=>B1 3=>B2 4=>B3\) has the same name and number$'
+			ResourceError, (
+				r'^Trying to add the connector pmod#0, but there is a previously added connector that has the same '
+				r'name and number$'
 			)
 		):
 			self.cm.add_connectors([Connector('pmod', 0, '1 2')])
@@ -261,26 +268,29 @@ class ResourceManagerTestCase(ToriiTestSuiteCase):
 	def test_wrong_lookup(self):
 		with self.assertRaisesRegex(
 			ResourceError,
-			r'^Resource user_led#1 does not exist$'
+			r'^The resource user_led#1 was requested but does not exist, did you mean user_led#0\?$'
 		):
 			self.cm.lookup('user_led', 1)
 
 	def test_wrong_clock_signal(self):
-		with self.assertRaisesRegex(TypeError, r'^Object None is not a Signal$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Object None is not a Signal \(test_res\.py, line \d+\)$'
+		):
 			self.cm.add_clock_constraint(None, 10 * MHz) # type: ignore
 
 	def test_wrong_clock_frequency(self):
 		with self.assertRaisesRegex(
-			TypeError,
+			ToriiSyntaxError,
 			r'^Clock frequency must be a `torii.hdl.time.Frequency`, a '
-			r'`float` or an `int`, not an <class \'NoneType\'>$'
+			r'`float` or an `int`, not an <class \'NoneType\'> \(test_res\.py, line \d+\)$'
 		):
 			self.cm.add_clock_constraint(Signal(), None) # type: ignore
 
 	def test_wrong_request_duplicate(self):
 		with self.assertRaisesRegex(
 			ResourceError,
-			r'^Resource user_led#0 has already been requested$'
+			r'^The resource user_led#0 has previously been requested$'
 		):
 			self.cm.request('user_led', 0)
 			self.cm.request('user_led', 0)
@@ -299,54 +309,50 @@ class ResourceManagerTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_request_with_dir(self):
 		with self.assertRaisesRegex(
-			TypeError, (
+			ToriiSyntaxError, (
 				r'^Direction must be one of \'i\', \'o\', \'oe\', \'io\', or \'-\', '
-				r'not \'wrong\'$'
+				r'not \'wrong\' \(test_res\.py, line \d+\)$'
 			)
 		):
 			self.cm.request('user_led', 0, dir = 'wrong')
 
 	def test_wrong_request_with_dir_io(self):
 		with self.assertRaisesRegex(
-			ValueError, (
+			ToriiSyntaxError, (
 				r'^Direction of \(pins o A0\) cannot be changed from \'o\' to \'i\'; direction '
 				r'can be changed from \'io\' to \'i\', \'o\', or \'oe\', or from anything '
-				r'to \'-\'$'
+				r'to \'-\' \(test_res\.py, line \d+\)$'
 			)
 		):
 			self.cm.request('user_led', 0, dir = 'i')
 
 	def test_wrong_request_with_dir_dict(self):
 		with self.assertRaisesRegex(
-			TypeError, (
-				r'^Directions must be a dict, not \'i\', because \(resource i2c 0 \(subsignal scl '
-				r'\(pins o N10\)\) \(subsignal sda \(pins io N11\)\)\) '
-				r'has subsignals$'
+			ResourceError, (
+				r'^Directions must be a dict, not \'i\', because i2c has 2 subsignals$'
 			)
 		):
 			self.cm.request('i2c', 0, dir = 'i')
 
 	def test_wrong_request_with_wrong_xdr(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Data rate of \(pins o A0\) must be a non-negative integer, not -1$'
+			ToriiSyntaxError,
+			r'^Data rate of \(pins o A0\) must be a non-negative integer, not -1 \(test_res\.py, line \d+\)$'
 		):
 			self.cm.request('user_led', 0, xdr = -1)
 
 	def test_wrong_request_with_xdr_dict(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Data rate must be a dict, not 2, because \(resource i2c 0 \(subsignal scl '
-			r'\(pins o N10\)\) \(subsignal sda \(pins io N11\)\)\) '
-			r'has subsignals$'
+			ResourceError,
+			r'^Data rate must be a dict, not 2, because i2c has 2 subsignals$'
 		):
 			self.cm.request('i2c', 0, xdr = 2)
 
 	def test_wrong_clock_constraint_twice(self):
 		clk100 = self.cm.request('clk100')
 		with self.assertRaisesRegex(
-			ValueError, (
-				r'^Cannot add clock constraint on \(sig clk100_0__i\), which is already '
+			ConstraintError, (
+				r'^Cannot add clock constraint of 1MHz to \(sig clk100_0__i\), which is already '
 				r'constrained to 100MHz$'
 			)
 		):

--- a/tests/platform/resources/test_interface.py
+++ b/tests/platform/resources/test_interface.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from torii.diagnostics                  import ResourceWarning
 from torii.platform.resources.interface import PCIBusResources, PCIeBusResources
 from torii.test                         import ToriiTestCase
 

--- a/torii/build/dsl.py
+++ b/torii/build/dsl.py
@@ -8,7 +8,9 @@ from typing          import TypeAlias
 from warnings        import warn
 
 from .._typing       import IODirectionOE
+from ..diagnostics   import ToriiSyntaxError
 from ..hdl.time      import Period, Frequency, GHz, kHz, MHz
+from ..util.tracer   import get_src_loc
 
 __all__ = (
 	'Attrs',
@@ -31,28 +33,38 @@ class Pins:
 
 	def __init__(
 		self, pins: str, *, dir: IODirectionOE = 'io', invert: bool = False, conn: ResourceConn | None = None,
-		assert_width: int | None = None
+		assert_width: int | None = None, src_loc_at: int = 0
 	) -> None:
+		self.src_loc = get_src_loc(src_loc_at)
+
 		if not isinstance(pins, str):
-			raise TypeError(f'Names must be a whitespace-separated string, not {pins!r}')
+			raise ToriiSyntaxError(
+				f'Names must be a whitespace-separated string, not {pins!r}',
+				src_loc = self.src_loc
+			)
 
 		names: list[str] = pins.split()
 
 		if conn is not None:
 			conn_name, conn_number = conn
 			if not (isinstance(conn_name, str) and isinstance(conn_number, (int, str))):
-				raise TypeError(
+				raise ToriiSyntaxError(
 					'Connector must be None or a pair of string (connector name) and '
-					f'integer/string (connector number), not {conn!r}'
+					f'integer/string (connector number), not {conn!r}',
+					src_loc = self.src_loc
 				)
 			names = [ f'{conn_name}_{conn_number}:{name}' for name in names ]
 
 		if dir not in ('i', 'o', 'io', 'oe'):
-			raise TypeError(f'Direction must be one of \'i\', \'o\', \'oe\', or \'io\', not {dir!r}')
+			raise ToriiSyntaxError(
+				f'Direction must be one of \'i\', \'o\', \'oe\', or \'io\', not {dir!r}',
+				src_loc = self.src_loc
+			)
 
 		if assert_width is not None and len(names) != assert_width:
-			raise AssertionError(
-				f'{len(names)} names are specified ({" ".join(names)}), but {assert_width} names are expected'
+			raise ToriiSyntaxError(
+				f'{len(names)} pin(s) are specified ({" ".join(names)}), but {assert_width} pin(s) are expected',
+				src_loc = self.src_loc
 			)
 
 		self.names  = names
@@ -74,7 +86,11 @@ class Pins:
 		for name in self.names:
 			while ':' in name:
 				if name not in mapping:
-					raise NameError(f'Resource {resource!r} refers to nonexistent connector pin {name}')
+					# TODO(aki): ensure `resource` is always a `Resource`, then we can clean this up
+					raise ToriiSyntaxError(
+						f'Resource {resource!r} refers to nonexistent connector pin {name}',
+						src_loc = self.src_loc
+					)
 				name = mapping[name]
 			mapped_names.append(name)
 		return mapped_names
@@ -83,13 +99,16 @@ class Pins:
 		return f'(pins{"-n" if self.invert else ""} {self.dir} {" ".join(self.names)})'
 
 def PinsN(
-	names: str, *, dir: IODirectionOE = 'io', conn: ResourceConn | None = None, assert_width: int | None = None
+	names: str, *, dir: IODirectionOE = 'io', conn: ResourceConn | None = None, assert_width: int | None = None,
+	src_loc_at: int = 0
 ) -> Pins:
 	'''
 	.. todo:: Document Me
 	'''
 
-	return Pins(names, dir = dir, invert = True, conn = conn, assert_width = assert_width)
+	return Pins(
+		names, dir = dir, invert = True, conn = conn, assert_width = assert_width, src_loc_at = src_loc_at + 1
+	)
 
 class DiffPairs:
 	'''
@@ -98,14 +117,24 @@ class DiffPairs:
 
 	def __init__(
 		self, p: str, n: str, *, dir: IODirectionOE = 'io', invert: bool = False, conn: ResourceConn | None = None,
-		assert_width: int | None = None
+		assert_width: int | None = None, src_loc_at: int = 0
 	) -> None:
-		self.p = Pins(p, dir = dir, conn = conn, assert_width = assert_width)
-		self.n = Pins(n, dir = dir, conn = conn, assert_width = assert_width)
+		self.src_loc = get_src_loc(src_loc_at)
+
+		self.p = Pins(p, dir = dir, conn = conn, assert_width = assert_width, src_loc_at = src_loc_at + 1)
+		self.n = Pins(n, dir = dir, conn = conn, assert_width = assert_width, src_loc_at = src_loc_at + 1)
 
 		if len(self.p.names) != len(self.n.names):
-			raise TypeError(
-				f'Positive and negative pins must have the same width, but {self.p!r} and {self.n!r} do not'
+			more_or_fewer = 'more' if len(self.p.names) > len(self.n.names) else 'fewer'
+
+			raise ToriiSyntaxError(
+				'Differential pairs must have a symmetric set of positive and negative pins, however '
+				f'{more_or_fewer} positive than negative pins were specified',
+				src_loc = self.src_loc,
+				notes = [
+					f'The following positive pins were specified: {", ".join(self.p.names)}',
+					f'The following negative pins were specified: {", ".join(self.n.names)}',
+				]
 			)
 
 		self.dir    = dir
@@ -124,23 +153,31 @@ class DiffPairs:
 		)
 
 def DiffPairsN(
-	p: str, n: str, *, dir: IODirectionOE = 'io', conn: ResourceConn | None = None, assert_width: int | None = None
+	p: str, n: str, *, dir: IODirectionOE = 'io', conn: ResourceConn | None = None, assert_width: int | None = None,
+	src_loc_at: int = 0
 ) -> DiffPairs:
 	'''
 	.. todo:: Document Me
 	'''
 
-	return DiffPairs(p = p, n = n, dir = dir, invert = True, conn = conn, assert_width = assert_width)
+	return DiffPairs(
+		p = p, n = n, dir = dir, invert = True, conn = conn, assert_width = assert_width, src_loc_at = src_loc_at + 1
+	)
 
 class Attrs(OrderedDict[str, int | str | Callable]):
 	'''
 	.. todo:: Document Me
 	'''
 
-	def __init__(self, **attrs: int | str | Callable) -> None:
+	def __init__(self, *, src_loc_at: int = 0, **attrs: int | str | Callable) -> None:
+		self.src_loc = get_src_loc(src_loc_at)
+
 		for key, value in attrs.items():
 			if not (value is None or isinstance(value, (str, int)) or hasattr(value, '__call__')):
-				raise TypeError(f'Value of attribute {key} must be None, int, str, or callable, not {value!r}')
+				raise ToriiSyntaxError(
+					f'Value of attribute {key} must be None, int, str, or callable, not {value!r}',
+					src_loc = self.src_loc
+				)
 
 		super().__init__(**attrs)
 
@@ -171,7 +208,9 @@ class Clock:
 		The frequency of this clock in Hertz.
 	'''
 
-	def __init__(self, frequency: Frequency | float | int) -> None:
+	def __init__(self, frequency: Frequency | float | int, *, src_loc_at: int = 0) -> None:
+		self.src_loc = get_src_loc(src_loc_at)
+
 		if isinstance(frequency, (float, int)):
 			warn(
 				f'Please use a `torii.hdl.time.Frequency` rather than a {type(frequency)} when specifying Clocks',
@@ -182,7 +221,7 @@ class Clock:
 		elif isinstance(frequency, Frequency):
 			self.frequency = frequency
 		else:
-			raise TypeError(
+			raise ToriiSyntaxError(
 				f'Clock frequency must be a `torii.hdl.time.Frequency`, a `float` or an `int`, not an {type(frequency)}'
 			)
 
@@ -212,7 +251,7 @@ class Clock:
 			stacklevel = 2
 		)
 
-		return Clock(frequency * kHz)
+		return Clock(frequency * kHz, src_loc_at = 1)
 
 	@classmethod
 	def from_mhz(cls: type['Clock'], frequency: float | int) -> 'Clock':
@@ -240,7 +279,7 @@ class Clock:
 			stacklevel = 2
 		)
 
-		return Clock(frequency * MHz)
+		return Clock(frequency * MHz, src_loc_at = 1)
 
 	@classmethod
 	def from_ghz(cls: type['Clock'], frequency: float | int) -> 'Clock':
@@ -268,7 +307,7 @@ class Clock:
 			stacklevel = 2
 		)
 
-		return Clock(frequency * GHz)
+		return Clock(frequency * GHz, src_loc_at = 1)
 
 	@property
 	def period(self) -> Period:
@@ -288,7 +327,9 @@ class Subsignal:
 	.. todo:: Document Me
 	'''
 
-	def __init__(self, name: str, *args: SubsigArgT) -> None:
+	def __init__(self, name: str, *args: SubsigArgT, src_loc_at: int = 0) -> None:
+		self.src_loc = get_src_loc(src_loc_at)
+
 		self.name                  = name
 		self.ios: list[SubsigArgT] = []
 		self.attrs                 = Attrs()
@@ -297,31 +338,39 @@ class Subsignal:
 		_subsig_names = set[str]()
 
 		if not args:
-			raise ValueError('Missing I/O constraints')
+			raise ToriiSyntaxError(
+				'Missing I/O constraints', src_loc = self.src_loc
+			)
 		for arg in args:
 			if isinstance(arg, (Pins, DiffPairs)):
 				if not self.ios:
 					self.ios.append(arg)
 				else:
-					raise TypeError(
+					# TODO(aki): Figure out how to clean up this message and make it better
+					raise ToriiSyntaxError(
 						'Pins and DiffPairs are incompatible with other location or '
-						f'subsignal constraints, but {arg!r} appears after {self.ios[-1]!r}'
+						f'subsignal constraints, but {arg!r} appears after {self.ios[-1]!r}',
+						src_loc = self.src_loc
 					)
 
 			elif isinstance(arg, Subsignal):
 				if not self.ios or isinstance(self.ios[-1], Subsignal):
 					if arg.name in _subsig_names:
-						raise NameError(
-							f'Attempted to add subsignal `{arg!r}` to `{self.name}` but a subsignal with that name'
-							' already exists.'
+						# TODO(aki): Do we want to track src locs here? I don't think so
+						raise ToriiSyntaxError(
+							f'Attempted to add subsignal `{arg.name}` to `{self.name}` but a subsignal with that name'
+							' already exists.',
+							src_loc = self.src_loc,
 						)
 
 					_subsig_names.add(arg.name)
 					self.ios.append(arg)
 				else:
-					raise TypeError(
+					# TODO(aki): Figure out how to clean up this message and make it better
+					raise ToriiSyntaxError(
 						'Subsignal is incompatible with location constraints, but '
-						f'{arg!r} appears after {self.ios[-1]!r}'
+						f'{arg!r} appears after {self.ios[-1]!r}',
+						src_loc = self.src_loc
 					)
 			elif isinstance(arg, Attrs):
 				self.attrs.update(arg)
@@ -330,11 +379,19 @@ class Subsignal:
 					if self.clock is None:
 						self.clock = arg
 					else:
-						raise ValueError('Clock constraint can be applied only once')
+						raise ToriiSyntaxError(
+							'Clock constraint can be applied only once', src_loc = self.src_loc
+						)
 				else:
-					raise TypeError(f'Clock constraint can only be applied to Pins or DiffPairs, not {self.ios[-1]!r}')
+					raise ToriiSyntaxError(
+						f'Clock constraint can only be applied to Pins or DiffPairs, not {self.ios[-1]!r}',
+						src_loc = self.src_loc
+					)
 			else:
-				raise TypeError(f'Constraint must be one of Pins, DiffPairs, Subsignal, Attrs, or Clock, not {arg!r}')
+				raise ToriiSyntaxError(
+					f'Constraint must be one of Pins, DiffPairs, Subsignal, Attrs, or Clock, not {arg!r}',
+					src_loc = self.src_loc
+				)
 
 	def _content_repr(self) -> str:
 		parts: list[str] = []
@@ -359,7 +416,8 @@ class Resource(Subsignal):
 	def family(
 		cls: type[Resource],
 		name_or_number: str | int, number: int | None = None, *,
-		ios: Sequence[SubsigArgT], default_name: str, name_suffix: str = ''
+		ios: Sequence[SubsigArgT], default_name: str, name_suffix: str = '',
+		src_loc_at: int = 0
 	) -> Resource:
 		'''
 		.. todo:: Document Me
@@ -380,15 +438,20 @@ class Resource(Subsignal):
 		# NOTE(aki): The type ignores here are silly but unless we do extra work to coerce the
 		#            `name_or_number` type due to the silly call then mypy will forever complain
 		if number is None: # name_or_number is number
-			return cls(default_name + name_suffix, name_or_number, *ios) # type: ignore
+			return cls(default_name + name_suffix, name_or_number, *ios, src_loc_at = 1 + src_loc_at) # type: ignore
 		else: # name_or_number is name
-			return cls(name_or_number + name_suffix, number, *ios) # type: ignore
+			return cls(name_or_number + name_suffix, number, *ios, src_loc_at = 1 + src_loc_at) # type: ignore
 
-	def __init__(self, name: str, number: int, *args: SubsigArgT) -> None:
+	def __init__(self, name: str, number: int, *args: SubsigArgT, src_loc_at: int = 0) -> None:
+		self.src_loc = get_src_loc(src_loc_at)
+
 		if not isinstance(number, int):
-			raise TypeError(f'Resource number must be an integer, not {number!r}')
+			raise ToriiSyntaxError(
+				f'Resource number must be an integer, not {number!r}',
+				src_loc = self.src_loc
+			)
 
-		super().__init__(name, *args)
+		super().__init__(name, *args, src_loc_at = src_loc_at + 1)
 		self.number = number
 
 	def __repr__(self) -> str:
@@ -399,17 +462,27 @@ class Connector:
 	.. todo:: Document Me
 	'''
 
-	def __init__(self, name: str, number: int, io: str | dict[str, str], *, conn: ResourceConn | None = None) -> None:
-		self.name   = name
-		self.number = number
-		mapping     = OrderedDict[str, str]()
+	def __init__(
+		self, name: str, number: int, io: str | dict[str, str], *, conn: ResourceConn | None = None,
+		src_loc_at: int = 0
+	) -> None:
+		self.name    = name
+		self.number  = number
+		self.src_loc = get_src_loc(src_loc_at)
+		mapping      = OrderedDict[str, str]()
 
 		if isinstance(io, dict):
 			for (conn_pin, plat_pin) in io.items():
 				if not isinstance(conn_pin, str):
-					raise TypeError(f'Connector pin name must be a string, not {conn_pin!r}')
+					raise ToriiSyntaxError(
+						f'Connector pin name must be a string, not {conn_pin!r}',
+						src_loc = self.src_loc
+					)
 				if not isinstance(plat_pin, str):
-					raise TypeError(f'Platform pin name must be a string, not {plat_pin!r}')
+					raise ToriiSyntaxError(
+						f'Platform pin name must be a string, not {plat_pin!r}',
+						src_loc = self.src_loc
+					)
 				mapping[conn_pin] = plat_pin
 
 		elif isinstance(io, str):
@@ -420,14 +493,18 @@ class Connector:
 
 				mapping[str(conn_pin)] = plat_pin
 		else:
-			raise TypeError(f'Connector I/Os must be a dictionary or a string, not {io!r}')
+			raise ToriiSyntaxError(
+				f'Connector I/Os must be a dictionary or a string, not {io!r}',
+				src_loc = self.src_loc
+			)
 
 		if conn is not None:
 			conn_name, conn_number = conn
 			if not (isinstance(conn_name, str) and isinstance(conn_number, (int, str))):
-				raise TypeError(
+				raise ToriiSyntaxError(
 					'Connector must be None or a pair of string (connector name) and integer/string '
-					f'(connector number), not {conn!r}'
+					f'(connector number), not {conn!r}',
+					src_loc = self.src_loc
 				)
 
 			for conn_pin, plat_pin in mapping.items():

--- a/torii/build/plat.py
+++ b/torii/build/plat.py
@@ -13,6 +13,7 @@ import jinja2
 
 from ..              import __version__
 from ..back          import rtlil, verilog
+from ..diagnostics   import PlatformError, ToriiError, ToriiSyntaxError
 from ..hdl.ast       import ClockSignal, Const, Signal
 from ..hdl.cd        import ClockDomain
 from ..hdl.dsl       import Module
@@ -25,6 +26,7 @@ from ..lib.io        import Pin
 from ..tools         import has_tool, require_tool
 from ..tools.yosys   import YosysBinary
 from ..util.string   import ascii_escape, tcl_escape, tcl_quote, tool_env_var
+from ..util.tracer   import get_src_loc
 from .dsl            import Attrs, Clock
 from .res            import ResourceManager
 from .run            import BuildPlan, BuildProducts
@@ -122,11 +124,11 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 
 		raise NotImplementedError('Platform must implement this property')
 
-	def __init__(self) -> None:
+	def __init__(self, *, src_loc_at: int = 0) -> None:
 		super().__init__(self.resources, self.connectors)
 
+		self.src_loc     = get_src_loc(src_loc_at)
 		self.extra_files = OrderedDict()
-
 		self._prepared   = False
 
 	@property
@@ -136,7 +138,11 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		'''
 
 		if self.default_clk is None:
-			raise AttributeError(f'Platform \'{type(self).__name__}\' does not define a default clock')
+			plat_name = getattr(self, 'pretty_name', type(self).__name__)
+			raise PlatformError(
+				message = f'Platform \'{plat_name}\' does not define a default clock',
+				src_loc = get_src_loc()
+			)
 
 		return self.lookup(self.default_clk).clock
 
@@ -148,7 +154,11 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 
 		constraint = self.default_clk_constraint
 		if constraint is None:
-			raise AttributeError(f'Platform \'{type(self).__name__}\' does not constrain its default clock')
+			plat_name = getattr(self, 'pretty_name', type(self).__name__)
+			raise PlatformError(
+				message = f'Platform \'{plat_name}\' does not constrain its default clock',
+				src_loc = get_src_loc()
+			)
 
 		return constraint.frequency
 
@@ -158,15 +168,24 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		'''
 
 		if not isinstance(filename, str):
-			raise TypeError(f'File name must be a string, not {filename!r}')
+			raise ToriiError(
+				message = f'File name must be a string, not {filename!r}',
+				src_loc = get_src_loc()
+			)
 		if hasattr(content, 'read'):
 			content = content.read()
 		elif not isinstance(content, (str, bytes)):
-			raise TypeError(f'File contents must be str, bytes, or a file-like object, not {content!r}')
+			raise ToriiError(
+				message = f'File contents must be str, bytes, or a file-like object, not {content!r}',
+				src_loc = get_src_loc()
+			)
 
 		if filename in self.extra_files:
 			if self.extra_files[filename] != content:
-				raise ValueError(f'File {filename!r} already exists')
+				raise ToriiError(
+					message = f'File {filename!r} already exists',
+					src_loc = get_src_loc()
+				)
 		else:
 			self.extra_files[filename] = content
 
@@ -265,7 +284,8 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		'''
 
 		if self._prepared:
-			raise RuntimeError(f'Design \'{name}\' is already prepared!')
+			# TODO(aki): We currently have limited src loc tracking for elaboratables/fragments
+			raise ToriiError(message = f'Design \'{name}\' is already prepared!')
 
 		self._prepared = True
 
@@ -309,13 +329,19 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		Convert the ``fragment`` and constraints recorded in this :py:class:`Platform` into
 		a :py:class:`BuildPlan`.
 		'''
+
 		raise NotImplementedError # :nocov:
 
 	def toolchain_program(self, products: BuildProducts, name: str, **kwargs) -> None:
 		'''
 		Extract bitstream for fragment ``name`` from ``products`` and download it to a target.
 		'''
-		raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support programming')
+
+		plat_name = getattr(self, 'pretty_name', type(self).__name__)
+		raise PlatformError(
+			message = f'Platform \'{plat_name}\' does not support programming',
+			src_loc = get_src_loc()
+		)
 
 	def _check_feature(
 		self, feature: PinFeature, pin: Pin, attrs: Attrs, valid_xdrs: tuple[int, ...], valid_attrs: str | None,
@@ -326,15 +352,25 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 		'''
 
 		if len(valid_xdrs) == 0:
-			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support {feature!s}')
+			plat_name = getattr(self, 'pretty_name', type(self).__name__)
+			raise PlatformError(
+				message = f'Platform \'{plat_name}\' does not support {feature!s}',
+				src_loc = pin.src_loc
+			)
 
 		elif pin.xdr not in valid_xdrs:
-			raise NotImplementedError(
-				f'Platform \'{type(self).__name__}\' does not support {feature!s} for XDR {pin.xdr}'
+			plat_name = getattr(self, 'pretty_name', type(self).__name__)
+			raise PlatformError(
+				message = f'Platform \'{plat_name}\' does not support {feature!s} for XDR {pin.xdr}',
+				src_loc = pin.src_loc
 			)
 
 		if not valid_attrs and attrs:
-			raise NotImplementedError(f'Platform \'{type(self).__name__}\' does not support attributes for {feature!s}')
+			plat_name = getattr(self, 'pretty_name', type(self).__name__)
+			raise PlatformError(
+				message = f'Platform \'{plat_name}\' does not support attributes for {feature!s}',
+				src_loc = attrs.src_loc
+			)
 
 	@staticmethod
 	def _invert_if(invert: bool, value):
@@ -431,7 +467,10 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
-		raise NotImplementedError('This platform does not support differential inputs')
+		raise PlatformError(
+			message = 'This platform does not support differential inputs',
+			src_loc = get_src_loc()
+		)
 
 	def get_diff_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
@@ -444,7 +483,10 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_OUTPUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
-		raise NotImplementedError('This platform does not support differential outputs')
+		raise PlatformError(
+			message = 'This platform does not support differential outputs',
+			src_loc = get_src_loc()
+		)
 
 	def get_diff_tristate(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
@@ -457,7 +499,10 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_TRISTATE, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
-		raise NotImplementedError('This platform does not implement differential tristate')
+		raise PlatformError(
+			message = 'This platform does not implement differential tristate',
+			src_loc = get_src_loc()
+		)
 
 	def get_diff_input_output(
 		self, pin: Pin, port: Record, attrs: Attrs, invert: bool, names: tuple[Iterable[str], Iterable[str]]
@@ -470,7 +515,10 @@ class Platform(ResourceManager, metaclass = ABCMeta):
 			PinFeature.DIFF_INOUT, pin, attrs, valid_xdrs = (), valid_attrs = None, names = names
 		)
 
-		raise NotImplementedError('This platform does not implement differential inputs/outputs')
+		raise PlatformError(
+			message = 'This platform does not implement differential inputs/outputs',
+			src_loc = get_src_loc()
+		)
 
 class TemplatedPlatform(Platform):
 	@property
@@ -544,9 +592,10 @@ class TemplatedPlatform(Platform):
 		# in the first place.
 		invalid_char = re.match(r'[^A-Za-z0-9_]', name)
 		if invalid_char:
-			raise ValueError(
+			raise ToriiSyntaxError(
 				f'Design name {name!r} contains invalid character {invalid_char.group(0)!r}; only alphanumeric '
-				'characters are valid in design names'
+				'characters are valid in design names',
+				src_loc = get_src_loc()
 			)
 
 		# This notice serves a dual purpose: to explain that the file is autogenerated,

--- a/torii/build/res.py
+++ b/torii/build/res.py
@@ -5,12 +5,14 @@ from collections.abc import Callable, Generator, Iterable
 from typing          import Literal
 from warnings        import warn
 
-from ..diagnostics   import ResourceError
-from .._typing       import IODirectionEmpty
+from ..diagnostics   import ConstraintError, ResourceError, ToriiSyntaxError
+from .._typing       import IODirectionEmpty, SrcLoc
 from ..hdl.ast       import Signal, SignalDict, Value, ValueCastable
 from ..hdl.rec       import Record
 from ..hdl.time      import Frequency
 from ..lib.io        import Pin
+from ..util.string   import _get_best_matching
+from ..util.tracer   import get_src_loc
 from .dsl            import Attrs, Connector, DiffPairs, Pins, Resource, Subsignal
 
 __all__ = (
@@ -19,67 +21,194 @@ __all__ = (
 
 class ResourceManager:
 	'''
-	.. todo:: Document Me
+	The base resource manager for Torii platforms.
+
+	It is responsible for keeping track of and doing resource and connector resolution,
+	as well as generating constraints for I/O and clocking where appropriate.
+
+	Parameters
+	----------
+	resources: list[Resource]
+		The list of resources to manage
+
+	connectors: list[Connectors]
+		The list of connectors to manage
 	'''
 
 	def __init__(self, resources: list[Resource], connectors: list[Connector]) -> None:
 		self.resources  = OrderedDict[tuple[str, int], Resource]()
-		self._requested = OrderedDict[tuple[str, int], Record | Pin]()
-		self._phys_reqd = OrderedDict[str, str]()
+		self._requested = OrderedDict[tuple[str, int], tuple[Record | Pin, SrcLoc]]()
+		self._phys_reqd = OrderedDict[str, tuple[str, SrcLoc]]()
 
 		self.connectors = OrderedDict[tuple[str, int], Connector]()
 		self._conn_pins = OrderedDict[str, str]()
 
 		# Constraint lists
 		self._ports     = list[tuple[Resource, Pin | None, Record, Attrs]]()
-		self._clocks    = SignalDict[Frequency]()
+		self._clocks    = SignalDict[tuple[Frequency, SrcLoc]]()
 
 		self.add_resources(resources)
 		self.add_connectors(connectors)
 
-	def add_resources(self, resources: Iterable[Resource]) -> None:
+	def add_resources(self, resources: Iterable[Resource], *, src_loc_at: int = 0) -> None:
 		'''
-		.. todo:: Document Me
+		Add one or more :py:class:`Resource <torii.build.dsl.Resource>`'s to the current platform.
+
+		Parameters
+		----------
+		resources: Iterable[Resource]
+			The Torii resources to add
+
+		Raises
+		------
+		ToriiSyntaxError
+			If an element in the resource list is not a :py:class:`Resource <torii.build.dsl.Resource>`
+
+		ResourceError
+			If the resource already exists
 		'''
 
 		for res in resources:
 			if not isinstance(res, Resource):
-				raise TypeError(f'Object {res!r} is not a Resource')
+				raise ToriiSyntaxError(
+					f'Object {res!r} is not a Resource', src_loc = get_src_loc(src_loc_at)
+				)
 			if (res.name, res.number) in self.resources:
-				raise NameError(
-					f'Trying to add {res!r}, but {self.resources[res.name, res.number]!r} has the same name and number'
+				ext_res = self.resources[res.name, res.number]
+
+				notes = list[str]()
+
+				if repr(res) == repr(ext_res):
+					notes.append(
+						'The previously defined resource appears to be identical to the current one'
+					)
+				else:
+					notes.append(
+						f'The previously defined resource has {len(ext_res.ios)} subsignals while the current resource '
+						f'has {len(res.ios)}',
+					)
+
+				raise ResourceError(
+					message = (
+						f'Trying to add the resource {res.name}#{res.number}, but there is a previously added '
+						'resource that has the same name and number'
+					),
+					src_loc = res.src_loc,
+					notes = notes,
+					additional_ctx = (
+						'Previous resource was declared here:',
+						ext_res.src_loc
+					)
 				)
 
 			self.resources[res.name, res.number] = res
 
-	def add_connectors(self, connectors: Iterable[Connector]) -> None:
+	def add_connectors(self, connectors: Iterable[Connector], *, src_loc_at: int = 0) -> None:
 		'''
-		.. todo:: Document Me
+		Add one or more :py:class:`Connector <torii.build.dsl.Connector>`'s to the current platform.
+
+		Parameters
+		----------
+		connectors: Iterable[Connector]
+			The Torii connectors to add
+
+		Raises
+		------
+		ToriiSyntaxError
+			If an element in the connectors list is not a :py:class:`Connector <torii.build.dsl.Connector>`
+
+		ResourceError
+			If the connector already exists
+
+		ResourceError
+			If a pin in the given connector is used by another connector
 		'''
 
 		for conn in connectors:
 			if not isinstance(conn, Connector):
-				raise TypeError(f'Object {conn!r} is not a Connector')
+				raise ToriiSyntaxError(
+					f'Object {conn!r} is not a Connector', src_loc = get_src_loc(src_loc_at)
+				)
 			if (conn.name, conn.number) in self.connectors:
-				raise NameError(
-					f'Trying to add {conn!r}, but {self.connectors[conn.name, conn.number]!r} '
-					'has the same name and number'
+				ext_conn = self.connectors[conn.name, conn.number]
+
+				notes = list[str]()
+
+				if conn.__repr__() == ext_conn.__repr__():
+					notes.append(
+						'The previously defined connector appears to be identical to the current one'
+					)
+				else:
+					notes.append(
+						f'The previously defined connector has {len(ext_conn.mapping.keys())} connections while the '
+						f'current connector has {len(conn.mapping.keys())}',
+					)
+
+				raise ResourceError(
+					message = (
+						f'Trying to add the connector {conn.name}#{conn.number}, but there is a previously added '
+						'connector that has the same name and number'
+					),
+					src_loc = conn.src_loc,
+					notes = notes,
+					additional_ctx = (
+						'Previous connector was declared here:',
+						ext_conn.src_loc
+					)
 				)
 
 			self.connectors[conn.name, conn.number] = conn
 
 			for conn_pin, plat_pin in conn:
 				if conn_pin in self._conn_pins:
-					raise ValueError(f'Connector pin {conn_pin!r} already in connector!')
+					raise ResourceError(
+						message = f'Connector pin {conn_pin!r} already in connector!',
+						src_loc = conn.src_loc
+					)
 				self._conn_pins[conn_pin] = plat_pin
 
-	def lookup(self, name: str, number: int = 0) -> Resource:
+	def lookup(self, name: str, number: int = 0, *, src_loc_at: int = 0) -> Resource:
 		'''
-		.. todo:: Document Me
+		Attempt to get the resource with the given name an number
+
+		Parameters
+		----------
+		name: str
+			The name of the resource to look for
+
+		number: int
+			The number of the resource to look for
+
+		Returns
+		-------
+		Resource
+			The resource if found
+
+		Raises
+		------
+		ResourceError
+			If the resource is not found
 		'''
 
 		if (name, number) not in self.resources:
-			raise ResourceError(f'Resource {name}#{number} does not exist')
+			src_loc = get_src_loc(src_loc_at)
+			matches = _get_best_matching(f'{name}#{number}', map(lambda r: f'{r[0]}#{r[1]}', self.resources.keys()))
+			additional_ctx = None
+
+			if len(matches) > 0:
+				match = matches[0]
+				message = f'The resource {name}#{number} was requested but does not exist, did you mean {match}?'
+				mname, mnumber = match.split('#')
+				additional_ctx = (
+					f'The resource {match} was defined here:',
+					self.resources[(mname, int(mnumber))].src_loc
+				)
+			else:
+				message = f'The resource {name}#{number} was requested, but does not exist'
+
+			raise ResourceError(
+				message = message, src_loc = src_loc, additional_ctx = additional_ctx
+			)
 
 		return self.resources[name, number]
 
@@ -89,12 +218,38 @@ class ResourceManager:
 		xdr: dict[str, int] | None = None
 	) -> Record | Pin:
 		'''
-		.. todo:: Document Me
+		Request the given resource from the platform.
+
+		Parameters
+		----------
+		name: str
+			The name of the resource to request
+
+		number: int
+			The number of the resource to request
+
+		dir: IODirection | None
+			The IO direction for the resource
+
+		xdr: dict[str, int] | None
+			The IO gearing for the resource
 		'''
 
-		resource = self.lookup(name, number)
+		src_loc = get_src_loc()
+
+		resource = self.lookup(name, number, src_loc_at = 1)
 		if (resource.name, resource.number) in self._requested:
-			raise ResourceError(f'Resource {name}#{number} has already been requested')
+			raise ResourceError(
+				message = f'The resource {name}#{number} has previously been requested',
+				src_loc = src_loc,
+				notes = [
+					'In order to prevent conflicts, Torii resources can only be requested once'
+				],
+				additional_ctx = (
+					f'The resource {name}#{number} was previously requested here:',
+					self._requested[(resource.name, resource.number)][1]
+				)
+			)
 
 		def merge_options(
 			subsignal: Subsignal,
@@ -112,10 +267,32 @@ class ResourceManager:
 					xdr = dict[str, int]()
 
 				if not isinstance(dir, dict):
-					raise TypeError(f'Directions must be a dict, not {dir!r}, because {subsignal!r} has subsignals')
+					subsigs = list(map(lambda s: f'\'{s.name}\'', subsignal.ios))
+					raise ResourceError(
+						message = (
+							f'Directions must be a dict, not {dir!r}, because {subsignal.name} has '
+							f'{len(subsigs)} subsignals'
+						),
+						src_loc = src_loc,
+						notes = [
+							f'The following subsignals are present in {subsignal.name}: {", ".join(subsigs)}',
+							f'For example, to set the direction for {subsigs[0]}, use {{{subsigs[0]}: \'-\' }}'
+						]
+					)
 
 				if not isinstance(xdr, dict):
-					raise TypeError(f'Data rate must be a dict, not {xdr!r}, because {subsignal!r} has subsignals')
+					subsigs = list(map(lambda s: f'\'{s.name}\'', subsignal.ios))
+					raise ResourceError(
+						message = (
+							f'Data rate must be a dict, not {xdr!r}, because {subsignal.name} has '
+							f'{len(subsigs)} subsignals'
+						),
+						src_loc = src_loc,
+						notes = [
+							f'The following subsignals are present in {subsignal.name}: {", ".join(subsigs)}',
+							f'For example, to set the gearing for {subsigs[0]}, use {{{subsigs[0]}: {xdr} }}'
+						]
+					)
 
 				for sub in subsignal.ios:
 					assert isinstance(sub, Subsignal)
@@ -134,18 +311,23 @@ class ResourceManager:
 					xdr = 0
 
 				if dir not in ('i', 'o', 'oe', 'io', '-'):
-					raise TypeError(
-						f'Direction must be one of \'i\', \'o\', \'oe\', \'io\', or \'-\', not {dir!r}'
+					raise ToriiSyntaxError(
+						f'Direction must be one of \'i\', \'o\', \'oe\', \'io\', or \'-\', not {dir!r}',
+						src_loc = pin.src_loc
 					)
 				if dir != pin.dir and not (pin.dir == 'io' or dir == '-'):
-					raise ValueError(
+					raise ToriiSyntaxError(
 						f'Direction of {pin!r} cannot be changed from \'{pin.dir}\' '
 						f'to \'{dir}\'; direction can be changed from \'io\' to \'i\', \'o\', or '
-						'\'oe\', or from anything to \'-\''
+						'\'oe\', or from anything to \'-\'',
+						src_loc = pin.src_loc
 					)
 
 				if not isinstance(xdr, int) or xdr < 0:
-					raise ValueError(f'Data rate of {subsignal.ios[0]!r} must be a non-negative integer, not {xdr!r}')
+					raise ToriiSyntaxError(
+						f'Data rate of {subsignal.ios[0]!r} must be a non-negative integer, not {xdr!r}',
+						src_loc = subsignal.src_loc
+					)
 
 			return (dir, xdr)
 
@@ -163,7 +345,10 @@ class ResourceManager:
 				if isinstance(attr_value, Callable):
 					attr_value = attr_value(self)
 					if attr_value is not None or not isinstance(attr_value, str):
-						raise TypeError(f'attr_value is expected to be either a str or None, not \'{attr_value!r}\'')
+						raise ToriiSyntaxError(
+							f'attr_value is expected to be either a str or None, not \'{attr_value!r}\'',
+							src_loc = attrs.src_loc
+						)
 
 				if attr_value is None:
 					del attrs[attr_key]
@@ -210,26 +395,42 @@ class ResourceManager:
 					pin = None
 				else:
 					pin = Pin(len(phys), dir, xdr = xdr, name = name, diff = isinstance(phys, DiffPairs))
+					# Adjust source location, as this pin is dynamically generated at the request location
+					pin.src_loc = src_loc
 
 				for phys_name in phys_names:
 					if phys_name in self._phys_reqd:
+						pname, ploc = self._phys_reqd[phys_name]
+
 						raise ResourceError(
-							f'Resource component {name} uses physical pin {phys_name}, but it '
-							f'is already used by resource component {self._phys_reqd[phys_name]} that was '
-							'requested earlier'
+							message = (
+								f'Resource component {name} uses physical pin {phys_name}, but it '
+								f'is already used by resource component {pname} that was '
+								'requested earlier'
+							),
+							src_loc = src_loc,
+							additional_ctx = (
+								f'Pin {phys_name} was previously requested here:',
+								ploc
+							)
 						)
 
-					self._phys_reqd[phys_name] = name
+					self._phys_reqd[phys_name] = (name, src_loc)
 
 				self._ports.append((resource, pin, port, attrs))
 
 				if pin is not None and resource.clock is not None:
 					self.add_clock_constraint(pin.i, resource.clock.frequency)
+					# Fix-up the source location information
+					self._clocks[pin.i] = (self._clocks[pin.i][0], resource.clock.src_loc)
 
 				return pin if pin is not None else port
 
 			else:
-				raise TypeError(f'Expected a Subsignal, Pin, or DiffPairs, not a \'{resource.ios[0]!r}\'') # :nocov:
+				raise ToriiSyntaxError(
+					f'Expected a Subsignal, Pin, or DiffPairs, not a \'{resource.ios[0]!r}\'',
+					src_loc = resource.src_loc
+				) # :nocov:
 
 		value = resolve(
 			resource,
@@ -237,15 +438,13 @@ class ResourceManager:
 			name = f'{resource.name}_{resource.number}',
 			attrs = resource.attrs
 		)
-		self._requested[resource.name, resource.number] = value
+		self._requested[resource.name, resource.number] = (value, src_loc)
 		return value
 
 	def iter_single_ended_pins(self) -> Generator[tuple[
 		Pin, Record, Attrs, bool, Iterable[str]
 	], None, None]:
-		'''
-		.. todo:: Document Me
-		'''
+		''' Iterate over all single-ended pins in all resources '''
 
 		for res, pin, port, attrs in self._ports:
 			if pin is None:
@@ -256,9 +455,7 @@ class ResourceManager:
 	def iter_differential_pins(self) -> Generator[tuple[
 		Pin, Record, Attrs, bool, tuple[Iterable[str], Iterable[str]]
 	], None, None]:
-		'''
-		.. todo:: Document Me
-		'''
+		''' Iterate over all differential pins in all resources '''
 
 		for res, pin, port, attrs in self._ports:
 			if pin is None:
@@ -272,16 +469,12 @@ class ResourceManager:
 	def should_skip_port_component(
 		self, port: Record | None, attrs: Attrs, component: Literal['io', 'i', 'o', 'p', 'n', 'oe']
 	) -> bool:
-		'''
-		.. todo:: Document Me
-		'''
+		''' Determine if the given port should be skipped or not '''
 
 		return False
 
 	def iter_ports(self) -> Generator[ValueCastable | Value, None, None]:
-		'''
-		.. todo:: Document Me
-		'''
+		''' Iterate over all ports in all resources '''
 
 		for res, pin, port, attrs in self._ports:
 			if isinstance(res.ios[0], Pins):
@@ -296,9 +489,7 @@ class ResourceManager:
 				raise TypeError(f'Expected either \'Pins\', or \'DiffPairs\', not \'{res.ios[0]!r}\'')
 
 	def iter_port_constraints(self):
-		'''
-		.. todo:: Document Me
-		'''
+		''' Iterate over all ports in all resources for the purpose of generating IO constraints '''
 
 		for res, pin, port, attrs in self._ports:
 			if isinstance(res.ios[0], Pins):
@@ -319,7 +510,8 @@ class ResourceManager:
 		tuple[str, str, Attrs], None, None
 	]:
 		'''
-		.. todo:: Document Me
+		Iterate over all ports in all resources for the purpose of generating IO constraints,
+		flattening multi-bit ports where appropriate
 		'''
 
 		for port_name, pin_names, attrs in self.iter_port_constraints():
@@ -329,17 +521,34 @@ class ResourceManager:
 				for bit, pin_name in enumerate(pin_names):
 					yield (f'{port_name}[{bit}]', pin_name, attrs)
 
-	def add_clock_constraint(self, clock: Signal, frequency: Frequency | int | float) -> None:
+	def add_clock_constraint(
+		self, clock: Signal, frequency: Frequency | int | float, *, src_loc_at: int = 0
+	) -> None:
 		'''
-		.. todo:: Document Me
+		Add a clock constraint to the given signal
+
+		Parameters
+		----------
+		clock: Signal
+			The clock signal to constrain
+
+		frequency: Frequency
+			The clock frequency to constrain the signal to
 		'''
+
+		src_loc = get_src_loc(src_loc_at)
 
 		if not isinstance(clock, Signal):
-			raise TypeError(f'Object {clock!r} is not a Signal')
+			raise ToriiSyntaxError(
+				f'Object {clock!r} is not a Signal',
+				src_loc = src_loc
+			)
 
 		if not isinstance(frequency, (Frequency, int, float)):
-			raise TypeError(
-				f'Clock frequency must be a `torii.hdl.time.Frequency`, a `float` or an `int`, not an {type(frequency)}'
+			raise ToriiSyntaxError(
+				'Clock frequency must be a `torii.hdl.time.Frequency`, a `float` or an `int`, not '
+				f'an {type(frequency)}',
+				src_loc = src_loc
 			)
 
 		if isinstance(frequency, (float, int)):
@@ -352,19 +561,26 @@ class ResourceManager:
 			frequency = Frequency(frequency)
 
 		if clock in self._clocks:
-			raise ValueError(
-				f'Cannot add clock constraint on {clock!r}, which is already constrained to {self._clocks[clock]}'
+			freq, loc = self._clocks[clock]
+			raise ConstraintError(
+				message = (
+					f'Cannot add clock constraint of {frequency} to {clock!r}, which is already constrained '
+					f'to {freq}'
+				),
+				src_loc = src_loc,
+				additional_ctx = (
+					f'Constraint for {freq} was previously applied here:',
+					loc
+				)
 			)
 
 		else:
-			self._clocks[clock] = frequency
+			self._clocks[clock] = (frequency, src_loc)
 
 	def iter_clock_constraints(self) -> Generator[
 		tuple[Signal | None, Signal | None, Frequency], None, None
 	]:
-		'''
-		.. todo:: Document Me
-		'''
+		''' Iterate over all clock constraints in all resources, applying back-propagation through the IO buffer '''
 
 		# Back-propagate constraints through the input buffer. For clock constraints on pins
 		# (the majority of cases), toolchains work better if the constraint is defined on the pin
@@ -384,8 +600,11 @@ class ResourceManager:
 				elif isinstance(res.ios[0], DiffPairs):
 					pin_i_to_port[pin.i] = port.p
 				else:
-					raise ValueError(f'Expected res.ios[0] to be a \'Pins\' or \'DiffPairs\', not {res.ios[0]!r}')
+					raise ToriiSyntaxError(
+						f'Expected res.ios[0] to be a \'Pins\' or \'DiffPairs\', not {res.ios[0]!r}',
+						src_loc = res.src_loc
+					)
 
-		for net_signal, frequency in self._clocks.items():
+		for net_signal, (frequency, _) in self._clocks.items():
 			port_signal = pin_i_to_port.get(net_signal)
 			yield (net_signal, port_signal, frequency)

--- a/torii/diagnostics/__init__.py
+++ b/torii/diagnostics/__init__.py
@@ -5,12 +5,13 @@ from .errors   import (
 	ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
 )
 from .warnings import (
-	DriverConflict, MustUseWarning, NameWarning, ResourceWarning, ToolWarning, ToriiSyntaxWarning,
-	ToriiWarning, UnusedElaboratable, UnusedProperty, YosysWarning,
+	ConstraintWarning, DriverConflict, MustUseWarning, NameWarning, PlatformWarning, ResourceWarning, ToolWarning,
+	ToriiSyntaxWarning, ToriiWarning, UnusedElaboratable, UnusedProperty, YosysWarning,
 )
 
 __all__ = (
 	'ConstraintError',
+	'ConstraintWarning',
 	'DomainError',
 	'DriverConflict',
 	'MustUseWarning',
@@ -32,4 +33,5 @@ __all__ = (
 	'YosysError',
 	'YosysWarning',
 	'PlatformError',
+	'PlatformWarning',
 )

--- a/torii/diagnostics/__init__.py
+++ b/torii/diagnostics/__init__.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from .errors   import (
-	DomainError, NameError, NameNotFound, NonSynthesizableError, ResourceError, ToolError, ToolNotFound,
-	ToriiError, ToriiSyntaxError, YosysError,
+	ConstraintError, DomainError, NameError, NameNotFound, NonSynthesizableError, PlatformError, ResourceError,
+	ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
 )
 from .warnings import (
 	DriverConflict, MustUseWarning, NameWarning, ResourceWarning, ToolWarning, ToriiSyntaxWarning,
@@ -10,6 +10,7 @@ from .warnings import (
 )
 
 __all__ = (
+	'ConstraintError',
 	'DomainError',
 	'DriverConflict',
 	'MustUseWarning',
@@ -30,4 +31,5 @@ __all__ = (
 	'UnusedProperty',
 	'YosysError',
 	'YosysWarning',
+	'PlatformError',
 )

--- a/torii/diagnostics/errors.py
+++ b/torii/diagnostics/errors.py
@@ -7,10 +7,12 @@ from .._typing import SrcLoc
 '''
 
 __all__ = (
+	'ConstraintError',
 	'DomainError',
 	'NameError',
 	'NameNotFound',
 	'NonSynthesizableError',
+	'PlatformError',
 	'ResourceError',
 	'ToolError',
 	'ToolNotFound',
@@ -69,6 +71,10 @@ class ToriiSyntaxError(SyntaxError):
 
 		super().__init__(message, (filename, lineno, None, None))
 
+class ConstraintError(ToriiError):
+	''' An invalid constraint '''
+	pass
+
 class NameError(ToriiError):
 	''' Invalid HDL construct name '''
 	pass
@@ -79,6 +85,10 @@ class NameNotFound(NameError):
 
 class NonSynthesizableError(ToriiSyntaxError):
 	''' Attempted synthesis of a non-synthesizable Torii construct '''
+	pass
+
+class PlatformError(ToriiError):
+	''' An error relating to some functionality of a Torii platform '''
 	pass
 
 class ToolError(ToriiError):

--- a/torii/diagnostics/errors.py
+++ b/torii/diagnostics/errors.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from .._typing import SrcLoc
+
 '''
 
 '''
@@ -21,11 +23,19 @@ class ToriiError(Exception):
 	''' The base class for all Torii errors '''
 
 	def __init__(
-		self, *args: object, src_loc: tuple[str, int] | None = None, notes: list[str] | None = None,
-		additional_ctx: tuple[str, tuple[str, int]] | None = None
+		self, *args: object, message: str | None = None, src_loc: SrcLoc | None = None,
+		notes: list[str] | None = None, additional_ctx: tuple[str, SrcLoc] | None = None
 	) -> None:
-		if src_loc is not None:
-			self.src_loc = src_loc
+		self.msg = message
+
+		if src_loc is None:
+			filename = None
+			lineno = None
+		else:
+			filename, lineno = src_loc
+
+		self.filename = filename
+		self.lineno = lineno
 
 		if notes is not None:
 			self.__notes__ = notes
@@ -33,14 +43,17 @@ class ToriiError(Exception):
 		if additional_ctx is not None:
 			self.additional_ctx = additional_ctx
 
-		super().__init__(*args)
+		if len(args) == 0 and message is not None:
+			super().__init__(message)
+		else:
+			super().__init__(*args)
 
 class ToriiSyntaxError(SyntaxError):
 	''' Malformed or incorrect Torii code '''
 
 	def __init__(
-		self, message: str, src_loc: tuple[str, int] | None, *, notes: list[str] | None = None,
-		additional_ctx: tuple[str, tuple[str, int]] | None = None
+		self, message: str, src_loc: SrcLoc | None, *, notes: list[str] | None = None,
+		additional_ctx: tuple[str, SrcLoc] | None = None
 	) -> None:
 		if src_loc is None:
 			filename = None

--- a/torii/diagnostics/hooks.py
+++ b/torii/diagnostics/hooks.py
@@ -25,7 +25,7 @@ from rich.padding  import Padding
 from rich.panel    import Panel
 from rich.syntax   import Syntax
 
-from ..diagnostics import ToriiSyntaxError
+from ..diagnostics import ToriiError, ToriiSyntaxError
 from ..hdl._unused import MustUse
 
 # Create a reference to the handlers that are installed prior to us loading
@@ -332,19 +332,20 @@ def _excepthook(type: type[BaseException], value: BaseException, traceback: Trac
 	MustUse._MustUse__silence = True
 
 	# If it's a Torii SyntaxError, then we should try to emit a diagnostic
-	if isinstance(value, ToriiSyntaxError):
-		filename = value.filename
-		lineno = value.lineno
-		line = value.text
+	if isinstance(value, (ToriiError, ToriiSyntaxError)):
+		filename = getattr(value, 'filename', None)
+		lineno = getattr(value, 'lineno', None)
+		line = getattr(value, 'text', None)
+		msg = getattr(value, 'msg', None)
 
 		# If we don't have a filename and/or line number then there is very little we can do
-		if filename is None or lineno is None:
+		if filename is None or lineno is None or msg is None:
 			_EXCEPTHOOK_RESTORE(type, value, traceback)
 			return
 
 		cons = _get_console(stderr)
 		_render_diagnostic(
-			cons, value.msg, type, filename, lineno, 'red', line, getattr(value, '__notes__', None),
+			cons, msg, type, filename, lineno, 'red', line, getattr(value, '__notes__', None),
 			getattr(value, 'additional_ctx', None)
 		)
 	else:

--- a/torii/diagnostics/warnings.py
+++ b/torii/diagnostics/warnings.py
@@ -5,9 +5,11 @@
 '''
 
 __all__ = (
+	'ConstraintWarning',
 	'DriverConflict',
 	'MustUseWarning',
 	'NameWarning',
+	'PlatformWarning',
 	'ResourceWarning',
 	'ToolWarning',
 	'ToriiSyntaxWarning',
@@ -26,8 +28,15 @@ class ToriiSyntaxWarning(SyntaxWarning):
 	''' Inadvisable or potentially unwanted behavior from Torii code '''
 	pass
 
+class ConstraintWarning(ToriiWarning):
+	''' A constraint warning '''
+
 class NameWarning(ToriiWarning):
 	''' Inadvisable HDL construct name '''
+	pass
+
+class PlatformWarning(ToriiWarning):
+	''' A warning related to Torii platform functionality '''
 	pass
 
 class ToolWarning(ToriiWarning):

--- a/torii/platform/resources/display/__init__.py
+++ b/torii/platform/resources/display/__init__.py
@@ -23,22 +23,54 @@ def Display7SegResource(
 
 	ios: list[SubsigArgT] = []
 
-	ios.append(Subsignal('a', Pins(a, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('b', Pins(b, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('c', Pins(c, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('d', Pins(d, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('e', Pins(e, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('f', Pins(f, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('g', Pins(g, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
+	ios.append(Subsignal(
+		'a',
+		Pins(a, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'b',
+		Pins(b, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'c',
+		Pins(c, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'd',
+		Pins(d, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'e',
+		Pins(e, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'f',
+		Pins(f, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'g',
+		Pins(g, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
 
 	if dp is not None:
 		ios.append(Subsignal(
-			'dp', Pins(dp, dir = 'o', invert = invert, conn = conn, assert_width = 1)
+			'dp',
+			Pins(dp, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
 		))
 
 	if attrs is not None:
 		ios.append(attrs)
-	return Resource.family(name_or_number, number, default_name = 'display_7seg', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'display_7seg', ios = ios, src_loc_at = 1
+	)
 
 def HDMIResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -64,16 +96,48 @@ def HDMIResource(
 			dir_in = 'io'
 			dir_out = 'io'
 
-	ios.append(Subsignal('clk', DiffPairs(clk_p, clk_n, dir = dir_in, conn = conn, assert_width = 1), diff_attrs))
-	ios.append(Subsignal('d', DiffPairs(d_p, d_n, dir = dir_in, conn = conn, assert_width = 3), diff_attrs))
+	ios.append(Subsignal(
+		'clk',
+		DiffPairs(clk_p, clk_n, dir = dir_in, conn = conn, assert_width = 1, src_loc_at = 1),
+		diff_attrs,
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'd',
+		DiffPairs(d_p, d_n, dir = dir_in, conn = conn, assert_width = 3, src_loc_at = 1),
+		diff_attrs,
+		src_loc_at = 1
+	))
 	if cec:
-		ios.append(Subsignal('cec', Pins(cec, dir = 'io', conn = conn, assert_width = 1), attrs))
+		ios.append(Subsignal(
+			'cec',
+			Pins(cec, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
+		))
 	if hpd:
-		ios.append(Subsignal('hpd', Pins(hpd, dir = dir_out, conn = conn, assert_width = 1), attrs))
-	ios.append(Subsignal('sda', Pins(sda, dir = 'io', conn = conn, assert_width = 1), attrs))
-	ios.append(Subsignal('scl', Pins(scl, dir = 'io', conn = conn, assert_width = 1), attrs))
+		ios.append(Subsignal(
+			'hpd',
+			Pins(hpd, dir = dir_out, conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
+		))
+	ios.append(Subsignal(
+		'sda',
+		Pins(sda, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1),
+		attrs,
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'scl',
+		Pins(scl, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1),
+		attrs,
+		src_loc_at = 1
+	))
 
-	return Resource.family(name_or_number, number, default_name = 'hdmi', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'hdmi', ios = ios, src_loc_at = 1
+	)
 
 def VGADACResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -87,15 +151,35 @@ def VGADACResource(
 
 	ios: list[SubsigArgT] = []
 
-	ios.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('r', Pins(r, dir = 'o', conn = conn)))
-	ios.append(Subsignal('g', Pins(g, dir = 'o', conn = conn)))
-	ios.append(Subsignal('b', Pins(b, dir = 'o', conn = conn)))
 	ios.append(Subsignal(
-		'hs', Pins(hs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1)
+		'clk',
+		Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
 	))
 	ios.append(Subsignal(
-		'vs', Pins(vs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1)
+		'r',
+		Pins(r, dir = 'o', conn = conn, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'g',
+		Pins(g, dir = 'o', conn = conn, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'b',
+		Pins(b, dir = 'o', conn = conn, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'hs',
+		Pins(hs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'vs',
+		Pins(vs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
 	))
 	for extra in extras:
 		ios.append(extra)
@@ -103,7 +187,9 @@ def VGADACResource(
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'vgadac', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'vgadac', ios = ios, src_loc_at = 1
+	)
 
 def VGAResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -117,17 +203,29 @@ def VGAResource(
 
 	ios: list[SubsigArgT] = []
 
-	ios.append(Subsignal('r', Pins(r, dir = 'o', conn = conn)))
-	ios.append(Subsignal('g', Pins(g, dir = 'o', conn = conn)))
-	ios.append(Subsignal('b', Pins(b, dir = 'o', conn = conn)))
 	ios.append(Subsignal(
-		'hs', Pins(hs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1)
+		'r', Pins(r, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
 	))
 	ios.append(Subsignal(
-		'vs', Pins(vs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1)
+		'g', Pins(g, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'b', Pins(b, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'hs',
+		Pins(hs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'vs',
+		Pins(vs, dir = 'o', invert = invert_sync, conn = conn, assert_width = 1, src_loc_at = 1),
+		src_loc_at = 1
 	))
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'vga', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'vga', ios = ios, src_loc_at = 1
+	)

--- a/torii/platform/resources/extensions/pmod.py
+++ b/torii/platform/resources/extensions/pmod.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-# Reference: https://www.digilentinc.com/Pmods/Digilent-Pmod_%20Interface_Specification.pdf
+# Reference: https://web.archive.org/web/20260319171338/https://digilent.com/reference/_media/reference/pmod/pmod-interface-specification-1_3_1.pdf # noqa: E501
 
 from ....build.dsl import Pins, PinsN, Resource, SubsigArgT, Subsignal
 
@@ -19,7 +19,9 @@ def PmodGPIOType1Resource(name: str, number: int, *args: SubsigArgT, pmod: int) 
 	.. todo:: Document Me
 	'''
 
-	return Resource(name, number, Pins('1 2 3 4', dir = 'io', conn = ('pmod', pmod)), *args)
+	return Resource(
+		name, number, Pins('1 2 3 4', dir = 'io', conn = ('pmod', pmod), src_loc_at = 1), *args, src_loc_at = 1
+	)
 
 def PmodSPIType2Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
 	'''
@@ -28,11 +30,12 @@ def PmodSPIType2Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -
 
 	return Resource(
 		name, number,
-		Subsignal('cs',   PinsN('1', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('clk',   Pins('2', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('copi',  Pins('3', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('cipo',  Pins('4', dir = 'i', conn = ('pmod', pmod))),
-		*args
+		Subsignal('cs',   PinsN('1', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('clk',   Pins('2', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('copi',  Pins('3', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('cipo',  Pins('4', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodSPIType2AResource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -42,13 +45,14 @@ def PmodSPIType2AResource(name: str, number: int, *args: SubsigArgT, pmod: int) 
 
 	return Resource(
 		name, number,
-		Subsignal('cs',   PinsN('1', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('clk',   Pins('2', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('copi',  Pins('3', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('cipo',  Pins('4', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('int',   Pins('7', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('reset', Pins('8', dir = 'o', conn = ('pmod', pmod))),
-		*args
+		Subsignal('cs',   PinsN('1', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('clk',   Pins('2', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('copi',  Pins('3', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('cipo',  Pins('4', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('int',   Pins('7', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('reset', Pins('8', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodUARTType3Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -58,11 +62,12 @@ def PmodUARTType3Resource(name: str, number: int, *args: SubsigArgT, pmod: int) 
 
 	return Resource(
 		name, number,
-		Subsignal('cts',   Pins('1', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('rts',   Pins('2', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('tx',    Pins('4', dir = 'o', conn = ('pmod', pmod))),
-		*args
+		Subsignal('cts',   Pins('1', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rts',   Pins('2', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx',    Pins('4', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodUARTType4Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -72,11 +77,12 @@ def PmodUARTType4Resource(name: str, number: int, *args: SubsigArgT, pmod: int) 
 
 	return Resource(
 		name, number,
-		Subsignal('cts',   Pins('1', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('tx',    Pins('2', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('rts',   Pins('4', dir = 'o', conn = ('pmod', pmod))),
-		*args
+		Subsignal('cts',   Pins('1', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx',    Pins('2', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rts',   Pins('4', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodUARTType4AResource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -86,13 +92,14 @@ def PmodUARTType4AResource(name: str, number: int, *args: SubsigArgT, pmod: int)
 
 	return Resource(
 		name, number,
-		Subsignal('cts',   Pins('1', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('tx',    Pins('2', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('rts',   Pins('4', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('int',   Pins('7', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('reset', Pins('8', dir = 'o', conn = ('pmod', pmod))),
-		*args
+		Subsignal('cts',   Pins('1', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx',    Pins('2', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rx',    Pins('3', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rts',   Pins('4', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('int',   Pins('7', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('reset', Pins('8', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodHBridgeType5Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -102,11 +109,12 @@ def PmodHBridgeType5Resource(name: str, number: int, *args: SubsigArgT, pmod: in
 
 	return Resource(
 		name, number,
-		Subsignal('dir',   Pins('1', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('en',    Pins('2', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('sa',    Pins('3', dir = 'i', conn = ('pmod', pmod))),
-		Subsignal('sb',    Pins('4', dir = 'i', conn = ('pmod', pmod))),
-		*args
+		Subsignal('dir',   Pins('1', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('en',    Pins('2', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('sa',    Pins('3', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('sb',    Pins('4', dir = 'i', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)
 
 def PmodDualHBridgeType6Resource(name: str, number: int, *args: SubsigArgT, pmod: int) -> Resource:
@@ -116,7 +124,8 @@ def PmodDualHBridgeType6Resource(name: str, number: int, *args: SubsigArgT, pmod
 
 	return Resource(
 		name, number,
-		Subsignal('dir',   Pins('1 3', dir = 'o', conn = ('pmod', pmod))),
-		Subsignal('en',    Pins('2 4', dir = 'o', conn = ('pmod', pmod))),
-		*args
+		Subsignal('dir',   Pins('1 3', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		Subsignal('en',    Pins('2 4', dir = 'o', conn = ('pmod', pmod), src_loc_at = 1), src_loc_at = 1),
+		*args,
+		src_loc_at = 1
 	)

--- a/torii/platform/resources/interface/bus.py
+++ b/torii/platform/resources/interface/bus.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from typing        import TYPE_CHECKING
-from warnings      import warn
+from typing          import TYPE_CHECKING
+from warnings        import warn
 
-from ...._typing   import IODirection
-from ....build.dsl import Attrs, Clock, DiffPairs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
-from ....hdl.time  import MHz
+from ...._typing     import IODirection
+from ....build.dsl   import Attrs, Clock, DiffPairs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....diagnostics import ResourceError, ResourceWarning
+from ....hdl.time    import MHz
+from ....util.tracer import get_src_loc
 
 __all__ = (
 	'DirectUSBResource',
@@ -25,19 +27,29 @@ def DirectUSBResource(
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('d_p', Pins(d_p, dir = 'io', conn = conn, assert_width = 1)))
-	io.append(Subsignal('d_n', Pins(d_n, dir = 'io', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'd_p', Pins(d_p, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'd_n', Pins(d_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if pullup:
-		io.append(Subsignal('pullup', Pins(pullup, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'pullup', Pins(pullup, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if vbus_valid:
-		io.append(Subsignal('vbus_valid', Pins(vbus_valid, dir = 'i', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'vbus_valid',
+			Pins(vbus_valid, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		))
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'usb', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'usb', ios = io, src_loc_at = 1)
 
 def PCIeBusResources(
 	name_or_number: str | int, number: int | None = None, *,
@@ -116,25 +128,40 @@ def PCIeBusResources(
 	io_common: list[Subsignal] = []
 
 	io_common.append(Subsignal(
-		'perst', PinsN(perst_n, dir = 'i', conn = conn, assert_width = 1), attrs
+		'perst',
+		PinsN(perst_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+		attrs,
+		src_loc_at = 1
 	))
 	io_common.append(Subsignal(
-		'refclk', DiffPairs(refclk_p, refclk_n, dir = 'i', conn = conn, assert_width = 1), refclk_attrs
+		'refclk',
+		DiffPairs(refclk_p, refclk_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+		refclk_attrs,
+		src_loc_at = 1
 	))
 
 	jtag_sigs = (tck, tdi, tdo, tms, trst_n,) # type: ignore
 
 	if wake_n is not None:
 		io_common.append(Subsignal(
-			'wake', PinsN(wake_n, dir = 'i', conn = conn, assert_width = 1), attrs
+			'wake',
+			PinsN(wake_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 
 	if smbclk is not None and smbdat is not None:
 		io_common.append(Subsignal(
-			'smbclk', Pins(smbclk, dir = 'io', conn = conn, assert_width = 1), attrs
+			'smbclk',
+			Pins(smbclk, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 		io_common.append(Subsignal(
-			'smbdat', Pins(smbdat, dir = 'io', conn = conn, assert_width = 1), attrs
+			'smbdat',
+			Pins(smbdat, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 	elif any((smbclk, smbdat,)):
 		warn(
@@ -148,36 +175,60 @@ def PCIeBusResources(
 			jtag_sigs: tuple[str, ...] = jtag_sigs
 
 		io_common.append(Subsignal(
-			'tck', Pins(jtag_sigs[0], dir = 'i', conn = conn, assert_width = 1), attrs
+			'tck',
+			Pins(jtag_sigs[0], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 		io_common.append(Subsignal(
-			'tdi', Pins(jtag_sigs[1], dir = 'i', conn = conn, assert_width = 1), attrs
+			'tdi',
+			Pins(jtag_sigs[1], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 		io_common.append(Subsignal(
-			'tdo', Pins(jtag_sigs[2], dir = 'o', conn = conn, assert_width = 1), attrs
+			'tdo',
+			Pins(jtag_sigs[2], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 		io_common.append(Subsignal(
-			'tms', Pins(jtag_sigs[3], dir = 'i', conn = conn, assert_width = 1), attrs
+			'tms',
+			Pins(jtag_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 		io_common.append(Subsignal(
-			'trst', PinsN(jtag_sigs[4], dir = 'i', conn = conn, assert_width = 1), attrs
+			'trst',
+			PinsN(jtag_sigs[4], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 
 	if clkreq_n is not None:
 		io_common.append(Subsignal(
-			'clkreq', PinsN(clkreq_n, dir = 'o', conn = conn, assert_width = 1), attrs
+			'clkreq',
+			PinsN(clkreq_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+			attrs,
+			src_loc_at = 1
 		))
 
 	io_x1 = list(io_common)
 	io_x1.append(Subsignal(
-		'pet0', DiffPairs(pet0_p, pet0_n, dir = 'o', conn = conn, assert_width = 1), lane_attrs
+		'pet0',
+		DiffPairs(pet0_p, pet0_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+		lane_attrs,
+		src_loc_at = 1
 	))
 	io_x1.append(Subsignal(
-		'per0', DiffPairs(per0_p, per0_n, dir = 'i', conn = conn, assert_width = 1), lane_attrs
+		'per0',
+		DiffPairs(per0_p, per0_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+		lane_attrs,
+		src_loc_at = 1
 	))
 
 	resources.append(Resource.family(
-		name_or_number, number, default_name = 'pcie', ios = io_x1, name_suffix = 'x1'
+		name_or_number, number, default_name = 'pcie', ios = io_x1, name_suffix = 'x1', src_loc_at = 1
 	))
 
 	io_x2: list[Subsignal] | None = None
@@ -231,14 +282,20 @@ def PCIeBusResources(
 			x2_sigs: tuple[str, ...] = x2_sigs
 
 		io_x2.append(Subsignal(
-			'pet1', DiffPairs(x2_sigs[0], x2_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+			'pet1',
+			DiffPairs(x2_sigs[0], x2_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+			lane_attrs,
+			src_loc_at = 1
 		))
 		io_x2.append(Subsignal(
-			'per1', DiffPairs(x2_sigs[2], x2_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+			'per1',
+			DiffPairs(x2_sigs[2], x2_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+			lane_attrs,
+			src_loc_at = 1
 		))
 
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'pcie', ios = io_x2, name_suffix = 'x2'
+			name_or_number, number, default_name = 'pcie', ios = io_x2, name_suffix = 'x2', src_loc_at = 1
 		))
 	elif any(x2_sigs):
 		warn(
@@ -257,23 +314,39 @@ def PCIeBusResources(
 				x4_sigs: tuple[str, ...] = x4_sigs
 
 			io_x4.append(Subsignal(
-				'pet2', DiffPairs(x4_sigs[0], x4_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet2',
+				DiffPairs(x4_sigs[0], x4_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x4.append(Subsignal(
-				'per2', DiffPairs(x4_sigs[2], x4_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per2',
+				DiffPairs(x4_sigs[2], x4_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x4.append(Subsignal(
-				'pet3', DiffPairs(x4_sigs[4], x4_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet3',
+				DiffPairs(x4_sigs[4], x4_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x4.append(Subsignal(
-				'per3', DiffPairs(x4_sigs[6], x4_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per3',
+				DiffPairs(x4_sigs[6], x4_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			if pwrbrk_n is not None:
-				io_x4.append(Subsignal('pwrbrk', PinsN(pwrbrk_n, dir = 'o', conn = conn, assert_width = 1)))
+				io_x4.append(Subsignal(
+					'pwrbrk',
+					PinsN(pwrbrk_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+					src_loc_at = 1
+				))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x4, name_suffix = 'x4'
+				name_or_number, number, default_name = 'pcie', ios = io_x4, name_suffix = 'x4', src_loc_at = 1
 			))
 		elif any(x4_sigs):
 			warn(
@@ -291,20 +364,32 @@ def PCIeBusResources(
 				x6_sigs: tuple[str, ...] = x6_sigs
 
 			io_x6.append(Subsignal(
-				'pet4', DiffPairs(x6_sigs[0], x6_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet4',
+				DiffPairs(x6_sigs[0], x6_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x6.append(Subsignal(
-				'per4', DiffPairs(x6_sigs[2], x6_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per4',
+				DiffPairs(x6_sigs[2], x6_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x6.append(Subsignal(
-				'pet5', DiffPairs(x6_sigs[4], x6_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet5',
+				DiffPairs(x6_sigs[4], x6_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x6.append(Subsignal(
-				'per5', DiffPairs(x6_sigs[6], x6_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per5',
+				DiffPairs(x6_sigs[6], x6_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x6, name_suffix = 'x6'
+				name_or_number, number, default_name = 'pcie', ios = io_x6, name_suffix = 'x6', src_loc_at = 1
 			))
 		elif any(x6_sigs):
 			warn(
@@ -323,20 +408,32 @@ def PCIeBusResources(
 				x8_sigs: tuple[str, ...] = x8_sigs
 
 			io_x8.append(Subsignal(
-				'pet6', DiffPairs(x8_sigs[0], x8_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet6',
+				DiffPairs(x8_sigs[0], x8_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x8.append(Subsignal(
-				'per6', DiffPairs(x8_sigs[2], x8_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per6',
+				DiffPairs(x8_sigs[2], x8_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x8.append(Subsignal(
-				'pet7', DiffPairs(x8_sigs[4], x8_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet7',
+				DiffPairs(x8_sigs[4], x8_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x8.append(Subsignal(
-				'per7', DiffPairs(x8_sigs[6], x8_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per7',
+				DiffPairs(x8_sigs[6], x8_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x8, name_suffix = 'x8'
+				name_or_number, number, default_name = 'pcie', ios = io_x8, name_suffix = 'x8', src_loc_at = 1
 			))
 		elif any(x8_sigs):
 			warn(
@@ -354,32 +451,56 @@ def PCIeBusResources(
 				x12_sigs: tuple[str, ...] = x12_sigs
 
 			io_x12.append(Subsignal(
-				'pet8', DiffPairs(x12_sigs[0], x12_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet8',
+				DiffPairs(x12_sigs[0], x12_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'per8', DiffPairs(x12_sigs[2], x12_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per8',
+				DiffPairs(x12_sigs[2], x12_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'pet9', DiffPairs(x12_sigs[4], x12_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet9',
+				DiffPairs(x12_sigs[4], x12_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'per9', DiffPairs(x12_sigs[6], x12_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per9',
+				DiffPairs(x12_sigs[6], x12_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'pet10', DiffPairs(x12_sigs[8], x12_sigs[9], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet10',
+				DiffPairs(x12_sigs[8], x12_sigs[9], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'per10', DiffPairs(x12_sigs[10], x12_sigs[11], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per10',
+				DiffPairs(x12_sigs[10], x12_sigs[11], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'pet11', DiffPairs(x12_sigs[12], x12_sigs[13], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet11',
+				DiffPairs(x12_sigs[12], x12_sigs[13], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x12.append(Subsignal(
-				'per11', DiffPairs(x12_sigs[14], x12_sigs[15], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per11',
+				DiffPairs(x12_sigs[14], x12_sigs[15], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x12, name_suffix = 'x12'
+				name_or_number, number, default_name = 'pcie', ios = io_x12, name_suffix = 'x12', src_loc_at = 1
 			))
 		elif any(x12_sigs):
 			warn(
@@ -398,32 +519,56 @@ def PCIeBusResources(
 				x16_sigs: tuple[str, ...] = x16_sigs
 
 			io_x16.append(Subsignal(
-				'pet12', DiffPairs(x16_sigs[0], x16_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet12',
+				DiffPairs(x16_sigs[0], x16_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'per12', DiffPairs(x16_sigs[2], x16_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per12',
+				DiffPairs(x16_sigs[2], x16_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'pet13', DiffPairs(x16_sigs[4], x16_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet13',
+				DiffPairs(x16_sigs[4], x16_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'per13', DiffPairs(x16_sigs[6], x16_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per13',
+				DiffPairs(x16_sigs[6], x16_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'pet14', DiffPairs(x16_sigs[8], x16_sigs[9], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet14',
+				DiffPairs(x16_sigs[8], x16_sigs[9], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'per14', DiffPairs(x16_sigs[10], x16_sigs[11], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per14',
+				DiffPairs(x16_sigs[10], x16_sigs[11], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'pet15', DiffPairs(x16_sigs[12], x16_sigs[13], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet15',
+				DiffPairs(x16_sigs[12], x16_sigs[13], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x16.append(Subsignal(
-				'per15', DiffPairs(x16_sigs[14], x16_sigs[15], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per15',
+				DiffPairs(x16_sigs[14], x16_sigs[15], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x16, name_suffix = 'x16'
+				name_or_number, number, default_name = 'pcie', ios = io_x16, name_suffix = 'x16', src_loc_at = 1
 			))
 		elif any(x16_sigs):
 			warn(
@@ -441,56 +586,104 @@ def PCIeBusResources(
 				x24_sigs: tuple[str, ...] = x24_sigs
 
 			io_x24.append(Subsignal(
-				'pet16', DiffPairs(x24_sigs[0], x24_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet16',
+				DiffPairs(x24_sigs[0], x24_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per16', DiffPairs(x24_sigs[2], x24_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per16',
+				DiffPairs(x24_sigs[2], x24_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet17', DiffPairs(x24_sigs[4], x24_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet17',
+				DiffPairs(x24_sigs[4], x24_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per17', DiffPairs(x24_sigs[6], x24_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per17',
+				DiffPairs(x24_sigs[6], x24_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet18', DiffPairs(x24_sigs[8], x24_sigs[9], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet18',
+				DiffPairs(x24_sigs[8], x24_sigs[9], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per18', DiffPairs(x24_sigs[10], x24_sigs[11], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per18',
+				DiffPairs(x24_sigs[10], x24_sigs[11], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet19', DiffPairs(x24_sigs[12], x24_sigs[13], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet19',
+				DiffPairs(x24_sigs[12], x24_sigs[13], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per19', DiffPairs(x24_sigs[14], x24_sigs[15], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per19',
+				DiffPairs(x24_sigs[14], x24_sigs[15], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet20', DiffPairs(x24_sigs[16], x24_sigs[17], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet20',
+				DiffPairs(x24_sigs[16], x24_sigs[17], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per20', DiffPairs(x24_sigs[18], x24_sigs[19], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per20',
+				DiffPairs(x24_sigs[18], x24_sigs[19], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet21', DiffPairs(x24_sigs[20], x24_sigs[21], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet21',
+				DiffPairs(x24_sigs[20], x24_sigs[21], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per21', DiffPairs(x24_sigs[22], x24_sigs[23], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per21',
+				DiffPairs(x24_sigs[22], x24_sigs[23], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet22', DiffPairs(x24_sigs[24], x24_sigs[25], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet22',
+				DiffPairs(x24_sigs[24], x24_sigs[25], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per22', DiffPairs(x24_sigs[26], x24_sigs[27], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per22',
+				DiffPairs(x24_sigs[26], x24_sigs[27], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'pet23', DiffPairs(x24_sigs[28], x24_sigs[29], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet23',
+				DiffPairs(x24_sigs[28], x24_sigs[29], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x24.append(Subsignal(
-				'per23', DiffPairs(x24_sigs[30], x24_sigs[31], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per23',
+				DiffPairs(x24_sigs[30], x24_sigs[31], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x24, name_suffix = 'x24'
+				name_or_number, number, default_name = 'pcie', ios = io_x24, name_suffix = 'x24', src_loc_at = 1
 			))
 		elif any(x24_sigs):
 			warn(
@@ -508,56 +701,104 @@ def PCIeBusResources(
 				x32_sigs: tuple[str, ...] = x32_sigs
 
 			io_x32.append(Subsignal(
-				'pet24', DiffPairs(x32_sigs[0], x32_sigs[1], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet24',
+				DiffPairs(x32_sigs[0], x32_sigs[1], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per24', DiffPairs(x32_sigs[2], x32_sigs[3], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per24',
+				DiffPairs(x32_sigs[2], x32_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet25', DiffPairs(x32_sigs[4], x32_sigs[5], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet25',
+				DiffPairs(x32_sigs[4], x32_sigs[5], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per25', DiffPairs(x32_sigs[6], x32_sigs[7], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per25',
+				DiffPairs(x32_sigs[6], x32_sigs[7], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet26', DiffPairs(x32_sigs[8], x32_sigs[9], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet26',
+				DiffPairs(x32_sigs[8], x32_sigs[9], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per26', DiffPairs(x32_sigs[10], x32_sigs[11], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per26',
+				DiffPairs(x32_sigs[10], x32_sigs[11], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet27', DiffPairs(x32_sigs[12], x32_sigs[13], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet27',
+				DiffPairs(x32_sigs[12], x32_sigs[13], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per27', DiffPairs(x32_sigs[14], x32_sigs[15], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per27',
+				DiffPairs(x32_sigs[14], x32_sigs[15], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet28', DiffPairs(x32_sigs[16], x32_sigs[17], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet28',
+				DiffPairs(x32_sigs[16], x32_sigs[17], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per28', DiffPairs(x32_sigs[18], x32_sigs[19], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per28',
+				DiffPairs(x32_sigs[18], x32_sigs[19], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet29', DiffPairs(x32_sigs[20], x32_sigs[21], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet29',
+				DiffPairs(x32_sigs[20], x32_sigs[21], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per29', DiffPairs(x32_sigs[22], x32_sigs[23], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per29',
+				DiffPairs(x32_sigs[22], x32_sigs[23], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet30', DiffPairs(x32_sigs[24], x32_sigs[25], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet30',
+				DiffPairs(x32_sigs[24], x32_sigs[25], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per30', DiffPairs(x32_sigs[26], x32_sigs[27], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per30',
+				DiffPairs(x32_sigs[26], x32_sigs[27], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'pet31', DiffPairs(x32_sigs[28], x32_sigs[29], dir = 'o', conn = conn, assert_width = 1), lane_attrs
+				'pet31',
+				DiffPairs(x32_sigs[28], x32_sigs[29], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 			io_x32.append(Subsignal(
-				'per31', DiffPairs(x32_sigs[30], x32_sigs[31], dir = 'i', conn = conn, assert_width = 1), lane_attrs
+				'per31',
+				DiffPairs(x32_sigs[30], x32_sigs[31], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1),
+				lane_attrs,
+				src_loc_at = 1
 			))
 
 			resources.append(Resource.family(
-				name_or_number, number, default_name = 'pcie', ios = io_x32, name_suffix = 'x32'
+				name_or_number, number, default_name = 'pcie', ios = io_x32, name_suffix = 'x32', src_loc_at = 1
 			))
 		elif any(x32_sigs):
 			warn(
@@ -593,34 +834,78 @@ def PCIBusResources(
 	resources: list[Resource]   = []
 	io_common: list[SubsigArgT] = []
 
-	io_common.append(Subsignal('inta', PinsN(inta_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('intb', PinsN(intb_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('intc', PinsN(intc_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('intd', PinsN(intd_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('rst', PinsN(rst_n, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('gnt', PinsN(gnt_n, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('req', PinsN(req_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('idsel', Pins(idsel, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('frame', PinsN(frame_n, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('irdy', PinsN(irdy_n, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('trdy', PinsN(trdy_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('devsel', PinsN(devsel_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('stop', PinsN(stop_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('lock', PinsN(lock_n, dir = 'i', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('perr', PinsN(perr_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('serr', PinsN(serr_n, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('smbclk', Pins(smbclk, dir = 'io', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('smbdat', Pins(smbdat, dir = 'io', conn = conn, assert_width = 1)))
+	io_common.append(Subsignal(
+		'inta', PinsN(inta_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'intb', PinsN(intb_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'intc', PinsN(intc_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'intd', PinsN(intd_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'rst', PinsN(rst_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'gnt', PinsN(gnt_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'req', PinsN(req_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'idsel', Pins(idsel, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'frame', PinsN(frame_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'irdy', PinsN(irdy_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'trdy', PinsN(trdy_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'devsel', PinsN(devsel_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'stop', PinsN(stop_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'lock', PinsN(lock_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'perr', PinsN(perr_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'serr', PinsN(serr_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'smbclk', Pins(smbclk, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_common.append(Subsignal(
+		'smbdat', Pins(smbdat, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if pme_n is not None:
-		io_common.append(Subsignal('pme', PinsN(pme_n, dir = 'io', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'pme', PinsN(pme_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if pcixcap is not None:
-		io_common.append(Subsignal('pcixcap', Pins(pcixcap, dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'pcixcap', Pins(pcixcap, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if m66en is not None:
-		io_common.append(Subsignal('m66en', Pins(m66en, dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'm66en', Pins(m66en, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	jtag_sigs = (tck, tdi, tdo, tms,) # type: ignore
 
@@ -629,22 +914,36 @@ def PCIBusResources(
 		if TYPE_CHECKING:
 			jtag_sigs: tuple[str, ...] = jtag_sigs
 
-		io_common.append(Subsignal('tck', Pins(jtag_sigs[0], dir = 'i', conn = conn, assert_width = 1)))
-		io_common.append(Subsignal('tdi', Pins(jtag_sigs[1], dir = 'i', conn = conn, assert_width = 1)))
-		io_common.append(Subsignal('tdo', Pins(jtag_sigs[2], dir = 'o', conn = conn, assert_width = 1)))
-		io_common.append(Subsignal('tms', Pins(jtag_sigs[3], dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'tck', Pins(jtag_sigs[0], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_common.append(Subsignal(
+			'tdi', Pins(jtag_sigs[1], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_common.append(Subsignal(
+			'tdo', Pins(jtag_sigs[2], dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_common.append(Subsignal(
+			'tms', Pins(jtag_sigs[3], dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if attrs is not None:
 		io_common.append(attrs)
 
 	io_32 = list(io_common)
 
-	io_32.append(Subsignal('ad_low', Pins(ad_lower, dir = 'io', conn = conn, assert_width = 32)))
-	io_32.append(Subsignal('cbe32', PinsN(cbe32_n, dir = 'io', conn = conn, assert_width = 4)))
-	io_32.append(Subsignal('par32', Pins(par32, dir = 'io', conn = conn, assert_width = 1)))
+	io_32.append(Subsignal(
+		'ad_low', Pins(ad_lower, dir = 'io', conn = conn, assert_width = 32, src_loc_at = 1), src_loc_at = 1
+	))
+	io_32.append(Subsignal(
+		'cbe32', PinsN(cbe32_n, dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1), src_loc_at = 1
+	))
+	io_32.append(Subsignal(
+		'par32', Pins(par32, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	resources.append(Resource.family(
-		name_or_number, number, default_name = 'pci', ios = io_32, name_suffix = '32'
+		name_or_number, number, default_name = 'pci', ios = io_32, name_suffix = '32', src_loc_at = 1
 	))
 
 	if (
@@ -653,14 +952,24 @@ def PCIBusResources(
 	):
 		io_64 = list(io_32)
 
-		io_64.append(Subsignal('ad_high', Pins(ad_upper, dir = 'io', conn = conn, assert_width = 32)))
-		io_64.append(Subsignal('cbe64', PinsN(cbe64_n, dir = 'io', conn = conn, assert_width = 4)))
-		io_64.append(Subsignal('par64', Pins(par64, dir = 'io', conn = conn, assert_width = 1)))
-		io_64.append(Subsignal('ack64', Pins(ack64_n, dir = 'io', conn = conn, assert_width = 1)))
-		io_64.append(Subsignal('req64', Pins(req64_n, dir = 'io', conn = conn, assert_width = 1)))
+		io_64.append(Subsignal(
+			'ad_high', Pins(ad_upper, dir = 'io', conn = conn, assert_width = 32, src_loc_at = 1), src_loc_at = 1
+		))
+		io_64.append(Subsignal(
+			'cbe64', PinsN(cbe64_n, dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1), src_loc_at = 1
+		))
+		io_64.append(Subsignal(
+			'par64', Pins(par64, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_64.append(Subsignal(
+			'ack64', Pins(ack64_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_64.append(Subsignal(
+			'req64', Pins(req64_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'pci', ios = io_64, name_suffix = '64'
+			name_or_number, number, default_name = 'pci', ios = io_64, name_suffix = '64', src_loc_at = 1
 		))
 
 	return resources
@@ -676,29 +985,44 @@ def ULPIResource(
 	'''
 
 	if clk_dir not in ('i', 'o'):
-		raise ValueError(f'clk_dir should be \'i\' or \'o\' not {clk_dir!r}')
+		raise ResourceError(
+			message = f'clk_dir should be \'i\' or \'o\' not {clk_dir!r}',
+			src_loc = get_src_loc()
+		)
 
-	clk_subsig = Subsignal('clk', Pins(clk, dir = clk_dir, conn = conn, assert_width = 1))
+	clk_subsig = Subsignal(
+		'clk', Pins(clk, dir = clk_dir, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	)
 	# If the clock is an input, we must constrain it to be 60MHz.
 	if clk_dir == 'i':
-		clk_subsig.clock = Clock(60 * MHz)
+		clk_subsig.clock = Clock(60 * MHz, src_loc_at = 1)
 	if clk_attrs is not None:
 		clk_subsig.attrs.update(clk_attrs)
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('data', Pins(data, dir = 'io', conn = conn, assert_width = 8)))
+	io.append(Subsignal(
+		'data', Pins(data, dir = 'io', conn = conn, assert_width = 8, src_loc_at = 1), src_loc_at = 1
+	))
 	io.append(clk_subsig)
-	io.append(Subsignal('dir', Pins(dir, dir = 'i', conn = conn, assert_width = 1)))
-	io.append(Subsignal('nxt', Pins(nxt, dir = 'i', conn = conn, assert_width = 1)))
-	io.append(Subsignal('stp', Pins(stp, dir = 'o', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'dir', Pins(dir, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'nxt', Pins(nxt, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'stp', Pins(stp, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if rst is not None:
 		io.append(Subsignal(
-			'rst', Pins(rst, dir = 'o', invert = rst_invert, conn = conn, assert_width = 1)
+			'rst',
+			Pins(rst, dir = 'o', invert = rst_invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
 		))
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'usb', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'usb', ios = io, src_loc_at = 1)

--- a/torii/platform/resources/interface/network.py
+++ b/torii/platform/resources/interface/network.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from ....build.dsl import Attrs, Pins, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....build.dsl   import Attrs, Pins, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....diagnostics import ResourceError
+from ....util.tracer import get_src_loc
 
 __all__ = (
 	'CANResource',
@@ -17,14 +19,16 @@ def CANResource(
 	'''
 
 	ios: list[SubsigArgT] = [
-		Subsignal('rx', Pins(rx, dir = 'i', conn = conn)),
-		Subsignal('tx', Pins(tx, dir = 'o', conn = conn)),
+		Subsignal('rx', Pins(rx, dir = 'i', conn = conn, src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx', Pins(tx, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1),
 	]
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'can', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'can', ios = ios, src_loc_at = 1
+	)
 
 def EthernetResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -41,54 +45,89 @@ def EthernetResource(
 	'''
 
 	if len(rxd.split()) not in (4, 8):
-		raise ValueError(
-			f'{len(rxd.split())} names are specified ({rxd}) but one of (4, 8) was expected'
+		raise ResourceError(
+			message = f'{len(rxd.split())} names are specified ({rxd}) but one of (4, 8) was expected',
+			src_loc = get_src_loc()
 		)
 
 	if len(txd.split()) not in (4, 8):
-		raise ValueError(
-			f'{len(txd.split())} names are specified ({txd}) but one of (4, 8) was expected'
+		raise ResourceError(
+			message = f'{len(txd.split())} names are specified ({txd}) but one of (4, 8) was expected',
+			src_loc = get_src_loc()
 		)
 
 	ios: list[SubsigArgT] = [
-		Subsignal('rx_clk', Pins(rxck, dir = 'i', conn = conn, assert_width = 1)),
-		Subsignal('rx_dat', Pins(rxd, dir = 'i', conn = conn)),
-		Subsignal('tx_clk', Pins(txck, dir = 'i', conn = conn, assert_width = 1)),
-		Subsignal('tx_dat', Pins(txd, dir = 'o', conn = conn)),
+		Subsignal('rx_clk', Pins(rxck, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1),
+		Subsignal('rx_dat', Pins(rxd, dir = 'i', conn = conn, src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx_clk', Pins(txck, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1),
+		Subsignal('tx_dat', Pins(txd, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1),
 	]
 
 	if rx_dv is not None and rx_err is not None:
 		if rx_ctl is not None:
-			raise ValueError('rx_ctl must be None!')
-		ios.append(Subsignal('rx_dv', Pins(rx_dv, dir = 'i', conn = conn, assert_width = 1)))
-		ios.append(Subsignal('rx_err', Pins(rx_err, dir = 'i', conn = conn, assert_width = 1)))
+			raise ResourceError(
+				message = 'rx_ctl must be None!', src_loc = get_src_loc()
+			)
+		ios.append(Subsignal(
+			'rx_dv', Pins(rx_dv, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		ios.append(Subsignal(
+			'rx_err', Pins(rx_err, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 	elif rx_ctl is not None:
-		ios.append(Subsignal('rx_ctl', Pins(rx_ctl, dir = 'i', conn = conn, assert_width = 1)))
+		ios.append(Subsignal(
+			'rx_ctl', Pins(rx_ctl, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 	else:
-		raise AssertionError('Must specify either MII RXDV + RXER pins or RGMII RXCTL')
+		raise ResourceError(
+			message = 'Must specify either MII RXDV + RXER pins or RGMII RXCTL',
+			src_loc = get_src_loc()
+		)
 
 	if tx_en is not None and tx_err is not None:
 		if tx_ctl is not None:
-			raise ValueError('tx_ctl must be None')
-		ios.append(Subsignal('tx_en', Pins(tx_en, dir = 'o', conn = conn, assert_width = 1)))
-		ios.append(Subsignal('tx_err', Pins(tx_err, dir = 'o', conn = conn, assert_width = 1)))
+			raise ResourceError(
+				message = 'tx_ctl must be None', src_loc = get_src_loc()
+			)
+		ios.append(Subsignal(
+			'tx_en', Pins(tx_en, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		ios.append(Subsignal(
+			'tx_err', Pins(tx_err, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 		if col is not None:
-			ios.append(Subsignal('col', Pins(col, dir = 'i', conn = conn, assert_width = 1)))
+			ios.append(Subsignal(
+				'col', Pins(col, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 		if crs is not None:
-			ios.append(Subsignal('crs', Pins(crs, dir = 'i', conn = conn, assert_width = 1)))
+			ios.append(Subsignal(
+				'crs', Pins(crs, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 	elif tx_ctl is not None:
 		if col is not None and crs is not None:
-			raise ValueError('col and crs must not be specified if tx_ctl is')
-		ios.append(Subsignal('tx_ctl', Pins(tx_ctl, dir = 'o', conn = conn, assert_width = 1)))
+			raise ResourceError(
+				message = 'col and crs must not be specified if tx_ctl is',
+				src_loc = get_src_loc()
+			)
+		ios.append(Subsignal(
+			'tx_ctl', Pins(tx_ctl, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 	else:
-		raise AssertionError('Must specify either MII TXDV + TXER pins or RGMII TXCTL')
+		raise ResourceError(
+			message = 'Must specify either MII TXDV + TXER pins or RGMII TXCTL',
+			src_loc = get_src_loc()
+		)
 
 	assert (rx_dv is not None and rx_err is not None) == (tx_en is not None and tx_err is not None)
 	assert (rx_ctl is not None) == (tx_ctl is not None)
 
 	if mdc is not None and mdio is not None and mdio_attrs is not None:
-		ios.append(Subsignal('mdc', Pins(mdc, dir = 'o', conn = conn, assert_width = 1), mdio_attrs))
-		ios.append(Subsignal('mdio', Pins(mdio, dir = 'io', conn = conn, assert_width = 1), mdio_attrs))
+		ios.append(Subsignal(
+			'mdc', Pins(mdc, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), mdio_attrs, src_loc_at = 1
+		))
+		ios.append(Subsignal(
+			'mdio', Pins(mdio, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), mdio_attrs, src_loc_at = 1
+		))
 	if attrs is not None:
 		ios.append(attrs)
-	return Resource.family(name_or_number, number, default_name = 'eth', ios = ios)
+	return Resource.family(name_or_number, number, default_name = 'eth', ios = ios, src_loc_at = 1)

--- a/torii/platform/resources/interface/serial.py
+++ b/torii/platform/resources/interface/serial.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from typing        import Literal
+from typing          import Literal
 
-from ....build.dsl import Attrs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....build.dsl   import Attrs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....diagnostics import ResourceError
+from ....util.tracer import get_src_loc
 
 __all__ = (
 	'I2CResource',
@@ -24,13 +26,17 @@ def I2CResource(
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('scl', Pins(scl, dir = 'io', conn = conn, assert_width = 1)))
-	io.append(Subsignal('sda', Pins(sda, dir = 'io', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'scl', Pins(scl, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'sda', Pins(sda, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'i2c', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'i2c', ios = io, src_loc_at = 1)
 
 def IrDAResource(
 	number: int, *,
@@ -44,23 +50,34 @@ def IrDAResource(
 	# Exactly one of en (active-high enable) or sd (shutdown, active-low enable) should
 	# be specified, and it is mapped to a logic level en subsignal.
 	if not (en is not None) ^ (sd is not None):
-		raise ValueError('Only en or sd may be specified, not both!')
+		raise ResourceError(
+			message = 'Only en or sd may be specified, not both!',
+			src_loc = get_src_loc()
+		)
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('rx', Pins(rx, dir = 'i', conn = conn, assert_width = 1)))
-	io.append(Subsignal('tx', Pins(tx, dir = 'o', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'rx', Pins(rx, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'tx', Pins(tx, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if en is not None:
-		io.append(Subsignal('en', Pins(en, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'en', Pins(en, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if sd is not None:
-		io.append(Subsignal('en', PinsN(sd, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'en', PinsN(sd, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource('irda', number, *io)
+	return Resource('irda', number, *io, src_loc_at = 1)
 
 def JTAGResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -72,14 +89,22 @@ def JTAGResource(
 	'''
 
 	ios: list[SubsigArgT] = [
-		Subsignal('tck', Pins(tck, dir = 'i', conn = conn, assert_width = 1)),
-		Subsignal('tms', Pins(tms, dir = 'i', conn = conn, assert_width = 1)),
-		Subsignal('tdi', Pins(tdi, dir = 'i', conn = conn, assert_width = 1)),
-		Subsignal('tdo', Pins(tdo, dir = 'oe', conn = conn, assert_width = 1)),
+		Subsignal(
+			'tck', Pins(tck, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		),
+		Subsignal(
+			'tms', Pins(tms, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		),
+		Subsignal(
+			'tdi', Pins(tdi, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		),
+		Subsignal(
+			'tdo', Pins(tdo, dir = 'oe', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		),
 	]
 	if attrs is not None:
 		ios.append(attrs)
-	return Resource.family(name_or_number, number, default_name = 'jtag', ios = ios)
+	return Resource.family(name_or_number, number, default_name = 'jtag', ios = ios, src_loc_at = 1)
 
 def PS2Resource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -92,13 +117,17 @@ def PS2Resource(
 
 	ios: list[SubsigArgT] = []
 
-	ios.append(Subsignal('clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('dat', Pins(dat, dir = 'io', conn = conn, assert_width = 1)))
+	ios.append(Subsignal(
+		'clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'dat', Pins(dat, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'ps2', ios = ios)
+	return Resource.family(name_or_number, number, default_name = 'ps2', ios = ios, src_loc_at = 1)
 
 def SPIResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -111,56 +140,98 @@ def SPIResource(
 	'''
 
 	if role not in ('controller', 'peripheral', 'generic'):
-		raise ValueError(f'role must be one of \'controller\', \'peripheral\', or \'generic\' not {role!r}')
+		raise ResourceError(
+			message = f'role must be one of \'controller\', \'peripheral\', or \'generic\' not {role!r}',
+			src_loc = get_src_loc()
+		)
 
 	# support unidirectional SPI
 	if copi is None and cipo is None:
-		raise ValueError('Either COPI or CIPO or both must be set, not none')
+		raise ResourceError(
+			message = 'Either COPI or CIPO or both must be set, not none',
+			src_loc = get_src_loc()
+		)
 
 	io: list[SubsigArgT] = []
 
 	if role == 'controller':
-		io.append(Subsignal('cs', PinsN(cs_n, dir = 'o', conn = conn)))
-		io.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'cs', PinsN(cs_n, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		))
+		io.append(Subsignal(
+			'clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 		if copi is not None:
-			io.append(Subsignal('copi', Pins(copi, dir = 'o', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'copi', Pins(copi, dir = 'o', conn = conn, assert_width = 1, src_loc_at =1), src_loc_at = 1
+			))
 		if cipo is not None:
-			io.append(Subsignal('cipo', Pins(cipo, dir = 'i', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'cipo', Pins(cipo, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 	elif role == 'peripheral':
-		io.append(Subsignal('cs', PinsN(cs_n, dir = 'i', conn = conn, assert_width = 1)))
-		io.append(Subsignal('clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'cs', PinsN(cs_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io.append(Subsignal(
+			'clk', Pins(clk, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 		if copi is not None:
-			io.append(Subsignal('copi', Pins(copi, dir = 'i', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'copi', Pins(copi, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+			))
 		if cipo is not None:
-			io.append(Subsignal('cipo', Pins(cipo, dir = 'oe', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'cipo', Pins(cipo, dir = 'oe', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 	else: # generic
-		io.append(Subsignal('cs', PinsN(cs_n, dir = 'io', conn = conn, assert_width = 1)))
-		io.append(Subsignal('clk', Pins(clk, dir = 'io', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'cs', PinsN(cs_n, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io.append(Subsignal(
+			'clk', Pins(clk, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 		if copi is not None:
-			io.append(Subsignal('copi', Pins(copi, dir = 'io', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'copi', Pins(copi, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 		if cipo is not None:
-			io.append(Subsignal('cipo', Pins(cipo, dir = 'io', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'cipo', Pins(cipo, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 
 	if int is not None:
 		if role == 'controller':
-			io.append(Subsignal('int', Pins(int, dir = 'i', conn = conn)))
+			io.append(Subsignal(
+				'int', Pins(int, dir = 'i', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
 		elif role == 'peripheral':
-			io.append(Subsignal('int', Pins(int, dir = 'oe', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'int', Pins(int, dir = 'oe', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 		else: # generic
-			io.append(Subsignal('int', Pins(int, dir = 'io', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'int', Pins(int, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 
 	if reset is not None:
 		if role == 'controller':
-			io.append(Subsignal('reset', Pins(reset, dir = 'o', conn = conn)))
+			io.append(Subsignal(
+				'reset', Pins(reset, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
 		elif role == 'peripheral':
-			io.append(Subsignal('reset', Pins(reset, dir = 'i', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'reset', Pins(reset, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 		else:  # generic
-			io.append(Subsignal('reset', Pins(reset, dir = 'io', conn = conn, assert_width = 1)))
+			io.append(Subsignal(
+				'reset', Pins(reset, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+			))
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'spi', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'spi', ios = io, src_loc_at = 1)
 
 def UARTResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -175,7 +246,10 @@ def UARTResource(
 
 	if any(line is not None for line in (rts, cts, dtr, dsr, dcd, ri)):
 		if role not in ('dce', 'dte'):
-			raise ValueError(f'Invalid role, expected \'dce\' or \'dte\', not \'{role}\'')
+			raise ResourceError(
+				message = f'Invalid role, expected \'dce\' or \'dte\', not \'{role}\'',
+				src_loc = get_src_loc()
+			)
 
 	if role == 'dte':
 		dce_to_dte = 'i'
@@ -186,31 +260,47 @@ def UARTResource(
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('rx', Pins(rx, dir = 'i', conn = conn, assert_width = 1)))
-	io.append(Subsignal('tx', Pins(tx, dir = 'o', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'rx', Pins(rx, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'tx', Pins(tx, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	# NOTE(aki): The mess of `# type: ignore` below is because the dte/dce
 	# 　　　　　　　role determination is hard to see through for mypy
 
 	if rts is not None:
-		io.append(Subsignal('rts', Pins(rts, dir = dte_to_dce, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'rts', Pins(rts, dir = dte_to_dce, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if cts is not None:
-		io.append(Subsignal('cts', Pins(cts, dir = dce_to_dte, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'cts', Pins(cts, dir = dce_to_dte, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if dtr is not None:
-		io.append(Subsignal('dtr', Pins(dtr, dir = dte_to_dce, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'dtr', Pins(dtr, dir = dte_to_dce, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if dsr is not None:
-		io.append(Subsignal('dsr', Pins(dsr, dir = dce_to_dte, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'dsr', Pins(dsr, dir = dce_to_dte, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if dcd is not None:
-		io.append(Subsignal('dcd', Pins(dcd, dir = dce_to_dte, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'dcd', Pins(dcd, dir = dce_to_dte, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if ri is not None:
-		io.append(Subsignal('ri', Pins(ri, dir = dce_to_dte, conn = conn, assert_width = 1))) # type: ignore
+		io.append(Subsignal(
+			'ri', Pins(ri, dir = dce_to_dte, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		)) # type: ignore
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'uart', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'uart', ios = io, src_loc_at = 1)

--- a/torii/platform/resources/memory/__init__.py
+++ b/torii/platform/resources/memory/__init__.py
@@ -35,46 +35,93 @@ def HyperBusResource(
 	'''
 
 	ios: list[SubsigArgT] = [
-		Subsignal('cs', PinsN(cs_n, dir = 'o' if bus_type == 'controller' else 'i', conn = conn, assert_width = 1)),
-		Subsignal('dq', Pins(dq, dir = 'io', conn = conn, assert_width = 8)),
-		Subsignal('rwds', Pins(rwds, dir = 'io', conn = conn, assert_width = 1)),
+		Subsignal(
+			'cs',
+			PinsN(
+				cs_n,
+				dir = 'o' if bus_type == 'controller' else 'i',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'dq', Pins(dq, dir = 'io', conn = conn, assert_width = 8, src_loc_at = 1), src_loc_at = 1
+		),
+		Subsignal(
+			'rwds', Pins(rwds, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		),
 	]
 
 	if clk_n is None:
-		ios.append(
-			Subsignal('clk', Pins(
-				clk_p, dir = 'o' if bus_type == 'controller' else 'i', conn = conn, assert_width = 1
-			))
-		)
+		ios.append(Subsignal(
+			'clk',
+			Pins(
+				clk_p,
+				dir = 'o' if bus_type == 'controller' else 'i',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			src_loc_at = 1
+		))
 	else:
-		ios.append(
-			Subsignal('clk', DiffPairs(
-				clk_p, clk_n, dir = 'o' if bus_type == 'controller' else 'i', conn = conn, assert_width = 1
-			), diff_attrs)
-		)
+		ios.append(Subsignal(
+			'clk',
+			DiffPairs(
+				clk_p, clk_n,
+				dir = 'o' if bus_type == 'controller' else 'i',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			diff_attrs,
+			src_loc_at = 1
+		))
 
 	if rst_n is not None:
-		ios.append(
-			Subsignal('rst', PinsN(
-				rst_n, dir = 'o' if bus_type == 'controller' else 'i', conn = conn, assert_width = 1
-			))
-		)
+		ios.append(Subsignal(
+			'rst',
+			PinsN(
+				rst_n,
+				dir = 'o' if bus_type == 'controller' else 'i',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			src_loc_at = 1
+		))
 
 	if rsto_n is not None:
-		ios.append(
-			Subsignal('rsto', PinsN(
-				rsto_n, dir = 'i' if bus_type == 'controller' else 'o', conn = conn, assert_width = 1
-			))
-		)
+		ios.append(Subsignal(
+			'rsto',
+			PinsN(
+				rsto_n,
+				dir = 'i' if bus_type == 'controller' else 'o',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			src_loc_at = 1
+		))
 
 	if int_n is not None:
-		ios.append(
-			Subsignal('int', PinsN(
-				int_n, dir = 'i' if bus_type == 'controller' else 'o', conn = conn, assert_width = 1
-			))
-		)
+		ios.append(Subsignal(
+			'int',
+			PinsN(
+				int_n,
+				dir = 'i' if bus_type == 'controller' else 'o',
+				conn = conn,
+				assert_width = 1,
+				src_loc_at = 1
+			),
+			src_loc_at = 1
+		))
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'hyperbus', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'hyperbus', ios = ios, src_loc_at = 1
+	)

--- a/torii/platform/resources/memory/flash.py
+++ b/torii/platform/resources/memory/flash.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from enum          import Enum, auto, unique
+from enum            import Enum, auto, unique
 
-from ....build.dsl import Attrs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....build.dsl   import Attrs, Pins, PinsN, Resource, ResourceConn, SubsigArgT, Subsignal
+from ....diagnostics import ResourceError
+from ....util.tracer import get_src_loc
 
 __all__ = (
 	'NORFlashResources',
@@ -48,39 +50,70 @@ def NORFlashResources(
 	io_common: list[SubsigArgT] = []
 
 	if rst is not None:
-		io_common.append(Subsignal('rst', Pins(rst, dir = 'o', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'rst', Pins(rst, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
-	io_common.append(Subsignal('cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('oe', PinsN(oe_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('wp', PinsN(wp_n, dir = 'o', conn = conn, assert_width = 1)))
-	io_common.append(Subsignal('rdy', Pins(by, dir = 'i', conn = conn, assert_width = 1)))
+	io_common.append(Subsignal(
+		'cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+	))
+	io_common.append(Subsignal(
+		'oe', PinsN(oe_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+	))
+	io_common.append(Subsignal(
+		'we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+	))
+	io_common.append(Subsignal(
+		'wp', PinsN(wp_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+	))
+	io_common.append(Subsignal(
+		'rdy', Pins(by, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at =1
+	))
 
 	if byte_n is None:
 		io_8bit = list(io_common)
-		io_8bit.append(Subsignal('a', Pins(a, dir = 'o', conn = conn)))
-		io_8bit.append(Subsignal('dq', Pins(dq, dir = 'io', conn = conn, assert_width = 8)))
+		io_8bit.append(Subsignal(
+			'a', Pins(a, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		))
+		io_8bit.append(Subsignal(
+			'dq', Pins(dq, dir = 'io', conn = conn, assert_width = 8, src_loc_at = 1), src_loc_at = 1
+		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'nor_flash', ios = io_8bit, name_suffix = '8bit'
+			name_or_number,
+			number,
+			default_name = 'nor_flash',
+			ios = io_8bit,
+			name_suffix = '8bit',
+			src_loc_at = 1
 		))
 	else:
 		*dq_0_14, dq15_am1 = dq.split()
 
 		# If present in a requested resource, this pin needs to be strapped correctly.
-		io_common.append(Subsignal('byte', PinsN(byte_n, dir = 'o', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'byte', PinsN(byte_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 		io_8bit = list(io_common)
-		io_8bit.append(Subsignal('a', Pins(' '.join((dq15_am1, a)), dir = 'o', conn = conn)))
-		io_8bit.append(Subsignal('dq', Pins(' '.join(dq_0_14[:8]), dir = 'io', conn = conn, assert_width = 8)))
+		io_8bit.append(Subsignal(
+			'a', Pins(' '.join((dq15_am1, a)), dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		))
+		io_8bit.append(Subsignal(
+			'dq', Pins(' '.join(dq_0_14[:8]), dir = 'io', conn = conn, assert_width = 8, src_loc_at = 1), src_loc_at = 1
+		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'nor_flash', ios = io_8bit, name_suffix = '8bit'
+			name_or_number, number, default_name = 'nor_flash', ios = io_8bit, name_suffix = '8bit', src_loc_at = 1
 		))
 
 		io_16bit = list(io_common)
-		io_16bit.append(Subsignal('a', Pins(a, dir = 'o', conn = conn)))
-		io_16bit.append(Subsignal('dq', Pins(dq, dir = 'io', conn = conn, assert_width = 16)))
+		io_16bit.append(Subsignal(
+			'a', Pins(a, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		))
+		io_16bit.append(Subsignal(
+			'dq', Pins(dq, dir = 'io', conn = conn, assert_width = 16, src_loc_at = 1), src_loc_at = 1
+		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'nor_flash', ios = io_16bit, name_suffix = '16bit'
+			name_or_number, number, default_name = 'nor_flash', ios = io_16bit, name_suffix = '16bit', src_loc_at = 1
 		))
 
 	return resources
@@ -97,52 +130,98 @@ def QSPIFlashResource(
 	'''
 
 	if not isinstance(mode, QSPIMode) or not isinstance(data_mode, QSPIDataMode):
-		raise AssertionError('mode must be a QSPIMode and data_mode a QSPIDataMode')
+		raise ResourceError(
+			message = 'mode must be a QSPIMode and data_mode a QSPIDataMode',
+			src_loc = get_src_loc()
+		)
 	elif mode == QSPIMode.Single and data_mode == QSPIDataMode.x8:
-		raise AssertionError('Cannot use x8 data mode in QSPI single mode')
+		raise ResourceError(
+			message = 'Cannot use x8 data mode in QSPI single mode',
+			src_loc = get_src_loc()
+		)
 	elif mode == QSPIMode.DualStacked and data_mode == QSPIDataMode.x8:
-		raise AssertionError('Cannot use x8 data mode in QSPI dual stacked mode')
+		raise ResourceError(
+			message = 'Cannot use x8 data mode in QSPI dual stacked mode',
+			src_loc = get_src_loc()
+		)
 	elif mode == QSPIMode.DualParallel and data_mode != QSPIDataMode.x8:
-		raise AssertionError('Must use x8 data mode in QSPI dual parallel mode')
+		raise ResourceError(
+			message = 'Must use x8 data mode in QSPI dual parallel mode',
+			src_loc = get_src_loc()
+		)
 
 	clk_count = 2 if mode == QSPIMode.DualParallel else 1
 	cs_count = 1 if mode == QSPIMode.Single else 2
 
 	ios: list[SubsigArgT] = [
-		Subsignal('cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = cs_count)),
-		Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = clk_count)),
+		Subsignal(
+			'cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = cs_count, src_loc_at = 1), src_loc_at = 1
+		),
+		Subsignal(
+			'clk', Pins(clk, dir = 'o', conn = conn, assert_width = clk_count, src_loc_at = 1), src_loc_at = 1
+		),
 	]
 
 	if mode == QSPIMode.DualParallel:
 		if dq is not None and (dq_a is None or dq_b is None):
-			raise ValueError(f'\'dq\' must be None and \'dq_a\' and \'dq_b\' must be specified for mode \'{mode}\'')
-		ios.append(Subsignal('dq_a', Pins(dq_a, dir = 'io', conn = conn, assert_width = 4)))
-		ios.append(Subsignal('dq_b', Pins(dq_b, dir = 'io', conn = conn, assert_width = 4)))
+			raise ResourceError(
+				message = f'\'dq\' must be None and \'dq_a\' and \'dq_b\' must be specified for mode \'{mode}\'',
+				src_loc = get_src_loc()
+			)
+		ios.append(Subsignal(
+			'dq_a', Pins(dq_a, dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1), src_loc_at = 1
+		))
+		ios.append(Subsignal(
+			'dq_b', Pins(dq_b, dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1), src_loc_at = 1
+		))
 	else:
 		if dq is None and (dq_a is not None or dq_b is not None):
-			raise ValueError(f'\'dq\' must be specified and \'dq_a\' and \'dq_b\' must be None for mode \'{mode}\'')
+			raise ResourceError(
+				message = f'\'dq\' must be specified and \'dq_a\' and \'dq_b\' must be None for mode \'{mode}\'',
+				src_loc = get_src_loc()
+			)
 
 		if data_mode == QSPIDataMode.x1:
 			dq = dq.split(' ')
 			if len(dq) != 3:
-				raise ValueError(f'dq must have exactly 3 pins, not {len(dq)}')
-			ios.append(Subsignal('copi', Pins(dq[0], dir = 'o', conn = conn)))
-			ios.append(Subsignal('cipo', Pins(dq[1], dir = 'i', conn = conn)))
-			ios.append(Subsignal('hold', PinsN(dq[2], dir = 'io', conn = conn)))
+				raise ResourceError(
+					message = f'dq must have exactly 3 pins, not {len(dq)}',
+					src_loc = get_src_loc()
+				)
+			ios.append(Subsignal(
+				'copi', Pins(dq[0], dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
+			ios.append(Subsignal(
+				'cipo', Pins(dq[1], dir = 'i', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
+			ios.append(Subsignal(
+				'hold', PinsN(dq[2], dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
 		elif data_mode == QSPIDataMode.x2:
 			dq = dq.split(' ')
 			if len(dq) != 3:
-				raise ValueError(f'dq must have exactly 3 pins not {len(dq)}')
-			ios.append(Subsignal('dq', Pins(f'{dq[0]} {dq[1]}', dir = 'io', conn = conn)))
-			ios.append(Subsignal('hold', PinsN(dq[2], dir = 'io', conn = conn)))
+				raise ResourceError(
+					message = f'dq must have exactly 3 pins not {len(dq)}',
+					src_loc = get_src_loc()
+				)
+			ios.append(Subsignal(
+				'dq', Pins(f'{dq[0]} {dq[1]}', dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
+			ios.append(Subsignal(
+				'hold', PinsN(dq[2], dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+			))
 		elif data_mode == QSPIDataMode.x4:
-			ios.append(Subsignal('dq', Pins(dq, dir = 'io', conn = conn, assert_width = 4)))
+			ios.append(Subsignal(
+				'dq', Pins(dq, dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1), src_loc_at = 1
+			))
 
 	if clk_fb is not None:
-		ios.append(Subsignal('clk_fb', Pins(clk_fb, dir = 'i', conn = conn, assert_width = 1)))
+		ios.append(Subsignal(
+			'clk_fb', Pins(clk_fb, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 	if attrs is not None:
 		ios.append(attrs)
-	return Resource.family(name_or_number, number, default_name = 'qspi', ios = ios)
+	return Resource.family(name_or_number, number, default_name = 'qspi', ios = ios, src_loc_at = 1)
 
 def SDCardResources(
 	name_or_number: str | int, number: int | None = None, *,
@@ -161,47 +240,71 @@ def SDCardResources(
 		io_common.append(attrs)
 
 	if cd is not None:
-		io_common.append(Subsignal('cd', Pins(cd, dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'cd', Pins(cd, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if wp_n is not None:
-		io_common.append(Subsignal('wp', PinsN(wp_n, dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'wp', PinsN(wp_n, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if det is not None:
-		io_common.append(Subsignal('det', Pins(det, dir = 'i', conn = conn, assert_width = 1)))
+		io_common.append(Subsignal(
+			'det', Pins(det, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	io_native = list(io_common)
-	io_native.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
-	io_native.append(Subsignal('cmd', Pins(cmd, dir = 'o', conn = conn, assert_width = 1)))
+	io_native.append(Subsignal(
+		'clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_native.append(Subsignal(
+		'cmd', Pins(cmd, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	io_1bit = list(io_native)
-	io_1bit.append(Subsignal('dat', Pins(dat0, dir = 'io', conn = conn, assert_width = 1)))
+	io_1bit.append(Subsignal(
+		'dat', Pins(dat0, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if dat3 is not None:
 		# DAT3 has a pullup and works as electronic card detect
-		io_1bit.append(Subsignal('ecd', Pins(dat3, dir = 'i', conn = conn, assert_width = 1)))
+		io_1bit.append(Subsignal(
+			'ecd', Pins(dat3, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	resources.append(Resource.family(
-		name_or_number, number, default_name = 'sd_card', ios = io_1bit, name_suffix = '1bit'
+		name_or_number, number, default_name = 'sd_card', ios = io_1bit, name_suffix = '1bit', src_loc_at = 1
 	))
 
 	if dat1 is not None and dat2 is not None and dat3 is not None:
 		io_4bit = list(io_native)
 		io_4bit.append(Subsignal(
-			'dat', Pins(' '.join((dat0, dat1, dat2, dat3)), dir = 'io', conn = conn, assert_width = 4)
+			'dat',
+			Pins(' '.join((dat0, dat1, dat2, dat3)), dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1),
+			src_loc_at = 1
 		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'sd_card', ios = io_4bit, name_suffix = '4bit'
+			name_or_number, number, default_name = 'sd_card', ios = io_4bit, name_suffix = '4bit', src_loc_at = 1
 		))
 
 	if dat3 is not None:
 		io_spi = list(io_common)
 		# DAT3/CS# has a pullup and doubles as electronic card detect
-		io_spi.append(Subsignal('cs', PinsN(dat3, dir = 'io', conn = conn, assert_width = 1)))
-		io_spi.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
-		io_spi.append(Subsignal('copi', Pins(cmd, dir = 'o', conn = conn, assert_width = 1)))
-		io_spi.append(Subsignal('cipo', Pins(dat0, dir = 'i', conn = conn, assert_width = 1)))
+		io_spi.append(Subsignal(
+			'cs', PinsN(dat3, dir = 'io', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_spi.append(Subsignal(
+			'clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_spi.append(Subsignal(
+			'copi', Pins(cmd, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_spi.append(Subsignal(
+			'cipo', Pins(dat0, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'sd_card', ios = io_spi, name_suffix = 'spi'
+			name_or_number, number, default_name = 'sd_card', ios = io_spi, name_suffix = 'spi', src_loc_at = 1
 		))
 
 	return resources
@@ -222,36 +325,52 @@ def SPIFlashResources(
 	if attrs is not None:
 		io_all.append(attrs)
 
-	io_all.append(Subsignal('cs',  PinsN(cs_n, dir = 'o', conn = conn)))
-	io_all.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
+	io_all.append(Subsignal(
+		'cs',  PinsN(cs_n, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	io_all.append(Subsignal(
+		'clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	io_1x = list(io_all)
-	io_1x.append(Subsignal('copi', Pins(copi, dir = 'o', conn = conn, assert_width = 1)))
-	io_1x.append(Subsignal('cipo', Pins(cipo, dir = 'i', conn = conn, assert_width = 1)))
+	io_1x.append(Subsignal(
+		'copi', Pins(copi, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io_1x.append(Subsignal(
+		'cipo', Pins(cipo, dir = 'i', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if wp_n is not None and hold_n is not None:
-		io_1x.append(Subsignal('wp',   PinsN(wp_n,   dir = 'o', conn = conn, assert_width = 1)))
-		io_1x.append(Subsignal('hold', PinsN(hold_n, dir = 'o', conn = conn, assert_width = 1)))
+		io_1x.append(Subsignal(
+			'wp',   PinsN(wp_n,   dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
+		io_1x.append(Subsignal(
+			'hold', PinsN(hold_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	resources.append(Resource.family(
-		name_or_number, number, default_name = 'spi_flash', ios = io_1x, name_suffix = '1x'
+		name_or_number, number, default_name = 'spi_flash', ios = io_1x, name_suffix = '1x', src_loc_at = 1
 	))
 
 	io_2x = list(io_all)
 	io_2x.append(Subsignal(
-		'dq', Pins(' '.join([copi, cipo]), dir = 'io', conn = conn, assert_width = 2)
+		'dq',
+		Pins(' '.join([copi, cipo]), dir = 'io', conn = conn, assert_width = 2, src_loc_at = 1),
+		src_loc_at = 1
 	))
 	resources.append(Resource.family(
-		name_or_number, number, default_name = 'spi_flash', ios = io_2x, name_suffix = '2x'
+		name_or_number, number, default_name = 'spi_flash', ios = io_2x, name_suffix = '2x', src_loc_at = 1
 	))
 
 	if wp_n is not None and hold_n is not None:
 		io_4x = list(io_all)
 		io_4x.append(Subsignal(
-			'dq', Pins(' '.join([copi, cipo, wp_n, hold_n]), dir = 'io', conn = conn, assert_width = 4)
+			'dq',
+			Pins(' '.join([copi, cipo, wp_n, hold_n]), dir = 'io', conn = conn, assert_width = 4, src_loc_at = 1),
+			src_loc_at = 1
 		))
 		resources.append(Resource.family(
-			name_or_number, number, default_name = 'spi_flash', ios = io_4x, name_suffix = '4x'
+			name_or_number, number, default_name = 'spi_flash', ios = io_4x, name_suffix = '4x', src_loc_at = 1
 		))
 
 	return resources

--- a/torii/platform/resources/memory/ram.py
+++ b/torii/platform/resources/memory/ram.py
@@ -24,25 +24,57 @@ def DDR3Resource(
 	ios: list[SubsigArgT] = []
 
 	if rst_n is not None:
-		ios.append(Subsignal('rst', PinsN(rst_n, dir = 'o', conn = conn, assert_width = 1)))
+		ios.append(Subsignal(
+			'rst', PinsN(rst_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
-	ios.append(Subsignal('clk', DiffPairs(clk_p, clk_n, dir = 'o', conn = conn, assert_width = 1), diff_attrs))
-	ios.append(Subsignal('clk_en', Pins(clk_en, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('ras', PinsN(ras_n, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('cas', PinsN(cas_n, dir = 'o', conn = conn, assert_width = 1)))
-	ios.append(Subsignal('a', Pins(a, dir = 'o', conn = conn)))
-	ios.append(Subsignal('ba', Pins(ba, dir = 'o', conn = conn)))
-	ios.append(Subsignal('dqs', DiffPairs(dqs_p, dqs_n, dir = 'io', conn = conn), diff_attrs))
-	ios.append(Subsignal('dq', Pins(dq, dir = 'io', conn = conn)))
-	ios.append(Subsignal('dm', Pins(dm, dir = 'o', conn = conn)))
-	ios.append(Subsignal('odt', Pins(odt, dir = 'o', conn = conn, assert_width = 1)))
+	ios.append(Subsignal(
+		'clk',
+		DiffPairs(clk_p, clk_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1),
+		diff_attrs,
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'clk_en', Pins(clk_en, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'ras', PinsN(ras_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'cas', PinsN(cas_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'a', Pins(a, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'ba', Pins(ba, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'dqs',
+		DiffPairs(dqs_p, dqs_n, dir = 'io', conn = conn, src_loc_at = 1),
+		diff_attrs,
+		src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'dq', Pins(dq, dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'dm', Pins(dm, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'odt', Pins(odt, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'ddr3', ios = ios)
+	return Resource.family(name_or_number, number, default_name = 'ddr3', ios = ios, src_loc_at = 1)
 
 def SDRAMResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -57,27 +89,47 @@ def SDRAMResource(
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'clk', Pins(clk, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 	if cke is not None:
-		io.append(Subsignal('clk_en', Pins(cke, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'clk_en', Pins(cke, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
 	if cs_n is not None:
-		io.append(Subsignal('cs', PinsN(cs_n,  dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'cs', PinsN(cs_n,  dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
-	io.append(Subsignal('we',  PinsN(we_n,  dir = 'o', conn = conn, assert_width = 1)))
-	io.append(Subsignal('ras', PinsN(ras_n, dir = 'o', conn = conn, assert_width = 1)))
-	io.append(Subsignal('cas', PinsN(cas_n, dir = 'o', conn = conn, assert_width = 1)))
-	io.append(Subsignal('ba', Pins(ba, dir = 'o', conn = conn)))
-	io.append(Subsignal('a',  Pins(a,  dir = 'o', conn = conn)))
-	io.append(Subsignal('dq', Pins(dq, dir = 'io', conn = conn)))
+	io.append(Subsignal(
+		'we',  PinsN(we_n,  dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'ras', PinsN(ras_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'cas', PinsN(cas_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'ba', Pins(ba, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'a',  Pins(a,  dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'dq', Pins(dq, dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if dqm is not None:
-		io.append(Subsignal('dqm', Pins(dqm, dir = 'o', conn = conn))) # dqm = 'LDQM# UDQM#'
+		io.append(Subsignal(
+			'dqm', Pins(dqm, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		)) # dqm = 'LDQM# UDQM#'
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'sdram', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'sdram', ios = io, src_loc_at = 1)
 
 def SRAMResource(
 	name_or_number: str | int, number: int | None = None, *,
@@ -91,20 +143,32 @@ def SRAMResource(
 
 	io: list[SubsigArgT] = []
 
-	io.append(Subsignal('cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1)))
+	io.append(Subsignal(
+		'cs', PinsN(cs_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if oe_n is not None:
 		# Asserted WE# deactivates the D output buffers, so WE# can be used to replace OE#.
-		io.append(Subsignal('oe', PinsN(oe_n, dir = 'o', conn = conn, assert_width = 1)))
+		io.append(Subsignal(
+			'oe', PinsN(oe_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+		))
 
-	io.append(Subsignal('we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1)))
-	io.append(Subsignal('a', Pins(a, dir = 'o', conn = conn)))
-	io.append(Subsignal('d', Pins(d, dir = 'io', conn = conn)))
+	io.append(Subsignal(
+		'we', PinsN(we_n, dir = 'o', conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'a', Pins(a, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
+	io.append(Subsignal(
+		'd', Pins(d, dir = 'io', conn = conn, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if dm_n is not None:
-		io.append(Subsignal('dm', PinsN(dm_n, dir = 'o', conn = conn))) # dm = 'LB# UB#'
+		io.append(Subsignal(
+			'dm', PinsN(dm_n, dir = 'o', conn = conn, src_loc_at = 1), src_loc_at = 1
+		)) # dm = 'LB# UB#'
 
 	if attrs is not None:
 		io.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'sram', ios = io)
+	return Resource.family(name_or_number, number, default_name = 'sram', ios = io, src_loc_at = 1)

--- a/torii/platform/resources/user.py
+++ b/torii/platform/resources/user.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from ..._typing   import IODirectionIO
-from ...build.dsl import Attrs, Pins, Resource, ResourceConn, SubsigArgT, Subsignal
+from ..._typing     import IODirectionIO
+from ...build.dsl   import Attrs, Pins, Resource, ResourceConn, SubsigArgT, Subsignal
+from ...diagnostics import ToriiSyntaxError
+from ...util.tracer import get_src_loc
 
 __all__ = (
 	'ButtonResources',
@@ -13,7 +15,7 @@ __all__ = (
 def _SplitResources(
 	name_or_number: str | int | None = None, number: int | None = None, *, default_name: str, dir: IODirectionIO,
 	pins: str | list[str] | dict[int, str], invert: bool = False, conn: ResourceConn | None = None,
-	attrs: Attrs | None = None,
+	attrs: Attrs | None = None, src_loc_at: int = 0
 ) -> list[Resource]:
 	'''
 	Create an array of simple named resources from a collection of pins.
@@ -62,7 +64,10 @@ def _SplitResources(
 	'''
 
 	if not isinstance(pins, (str, list, dict)):
-		raise TypeError(f'pins is expected to be a \'str\', \'list\', or \'dict\' not {pins!r}')
+		raise ToriiSyntaxError(
+			f'pins is expected to be a \'str\', \'list\', or \'dict\' not {pins!r}',
+			src_loc = get_src_loc(src_loc_at + 1)
+		)
 
 	if isinstance(pins, str):
 		pins = pins.split()
@@ -84,7 +89,9 @@ def _SplitResources(
 		number = 0
 
 	for idx, pin in pins.items():  # type: ignore
-		ios: list[Pins | Attrs] = [ Pins(pin, dir = dir, invert = invert, conn = conn) ]
+		ios: list[Pins | Attrs] = [
+			Pins(pin, dir = dir, invert = invert, conn = conn, src_loc_at = src_loc_at + 1)
+		]
 		if attrs is not None:
 			ios.append(attrs)
 		# NOTE(aki): This is likely problematic, but
@@ -92,7 +99,7 @@ def _SplitResources(
 		resources.append(Resource.family(
 			res_index if name is None else name,
 			res_index if name is not None else None,
-			default_name = default_name, ios = ios
+			default_name = default_name, ios = ios, src_loc_at = src_loc_at + 1
 		))
 
 	return resources
@@ -136,7 +143,7 @@ def ButtonResources(
 
 	return _SplitResources(
 		name_or_number, number, default_name = 'button', dir = 'i', pins = pins, invert = invert,
-		conn = conn, attrs = attrs
+		conn = conn, attrs = attrs, src_loc_at = 1
 	)
 
 def LEDResources(
@@ -178,7 +185,7 @@ def LEDResources(
 
 	return _SplitResources(
 		name_or_number, number, default_name = 'led', dir = 'o', pins = pins, invert = invert,
-		conn = conn, attrs = attrs
+		conn = conn, attrs = attrs, src_loc_at = 1
 	)
 
 def RGBLEDResource(
@@ -228,14 +235,22 @@ def RGBLEDResource(
 
 	ios: list[SubsigArgT] = []
 
-	ios.append(Subsignal('r', Pins(r, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('g', Pins(g, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
-	ios.append(Subsignal('b', Pins(b, dir = 'o', invert = invert, conn = conn, assert_width = 1)))
+	ios.append(Subsignal(
+		'r', Pins(r, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'g', Pins(g, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
+	ios.append(Subsignal(
+		'b', Pins(b, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1), src_loc_at = 1
+	))
 
 	if attrs is not None:
 		ios.append(attrs)
 
-	return Resource.family(name_or_number, number, default_name = 'rgb_led', ios = ios)
+	return Resource.family(
+		name_or_number, number, default_name = 'rgb_led', ios = ios, src_loc_at = 1
+	)
 
 def SwitchResources(
 	name_or_number: str | int | None = None, number: int | None = None, *,
@@ -276,5 +291,5 @@ def SwitchResources(
 
 	return _SplitResources(
 		name_or_number, number, default_name = 'switch', dir = 'i', pins = pins, invert = invert,
-		conn = conn, attrs = attrs
+		conn = conn, attrs = attrs, src_loc_at = 1
 	)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

Yet another PR in a long line of PRs improving the Torii diagnostics, this time it's mostly focused around the resource system with some light touches on the platforms to get them to be up to snuff a bit.

There is some weirdness in the source location tracking here, and I might have messed it up in some cases, but we won't know until they're hit.

One of the big "killer features" in this PR is constraint and resource tracking, Torii will point back to previously declared clock constraints, resources, and connectors.


The next step after this PR is to further flesh out the diagnostics for the downstream platforms, not the board files themselves, but the FPGA vendor platforms, they override a bunch of things, and there is some specialized machinery in them that needs extra care when it comes to doing proper diagnostics and source tracking, (I'm looking at you, Xilinx).

## Screenshots

<img width="2014" height="703" alt="image" src="https://github.com/user-attachments/assets/69f682be-6c9d-4623-adc9-a1ef324347a5" />

<img width="1987" height="694" alt="image" src="https://github.com/user-attachments/assets/b973efba-9c89-4e1d-8b92-f48b7f6024bb" />

<img width="1993" height="710" alt="image" src="https://github.com/user-attachments/assets/ee1575d2-2104-4301-9b81-ce65e7061c97" />

<img width="1988" height="693" alt="image" src="https://github.com/user-attachments/assets/174a2d68-098a-4a61-88c4-7eed467ed84f" />


# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
