### PR TITLE
Make `Frequency` and `Period` hashable

### DIFF
--- a/torii/hdl/time.py
+++ b/torii/hdl/time.py
@@ -187,6 +187,9 @@ class Frequency:
 		''' This frequency in Hertz '''
 		return self._value
 
+	def __hash__(self) -> int:
+		return hash(self._value)
+
 	def __rtruediv__(self, rep: int | float) -> 'Period':
 		if rep == 1:
 			warn('Consider using the `.period` attribute to get this Frequency as a Period', Warning, stacklevel = 2)
@@ -320,6 +323,9 @@ class Period:
 	def picoseconds(self) -> float:
 		''' This period in Picoseconds (10^-12 Seconds) '''
 		return self._value / PICO
+
+	def __hash__(self) -> int:
+		return hash(self._value)
 
 	def __rtruediv__(self, rep: int | float) -> 'Frequency':
 		if rep == 1:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

There may be some instances where someone would wish to do a dictionary lookup using a `Frequency` or `Period` as the key, for instance if you need to tune PLL settings (e.g. in [SOL])

This PR simply adds `__hash__` to `Period` and `Frequency` and just uses the `hash()` of their inner value.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
[SOL]: https://github.com/shrine-maiden-heavy-industries/sol/blob/9eb4c5f8b51cc93f4d11365162b669bfed40ac58/sol_usb/gateware/architecture/car.py#L187-L200