### PR TITLE
torii.hdl.dsl: Add `has_submodule` to `Module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Unreleased template stuff
 - Added support for Lattice Nexus devices with both Radiant and project oxide support
 - New `torii.hdl.time` Module with `Frequency` and `Period` constructs to unify how clocks are handled.
 - New enhanced diagnostics for Torii designs.
+- New `has_submodule` call on `Module`s to check if the current module has a named submodule.
 
 ### Changed
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -1078,3 +1078,11 @@ class DSLTestCase(ToriiTestSuiteCase):
 			'sync': SignalSet((self.c3,))
 		})
 		self.assertEqual(len(f2.subfragments), 0)
+
+	def test_has_submodule(self):
+		m1 = Module()
+		m2 = Module()
+		m1.submodules.nya = m2
+
+		self.assertTrue(m1.has_submodule('nya'))
+		self.assertFalse(m1.has_submodule('kon'))

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -923,3 +923,25 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		fragment.first_drivers = self._driving_locs
 		fragment.generated.update(self._generated)
 		return fragment
+
+	def has_submodule(self, name: str) -> bool:
+		'''
+		Check to see if a submodule with the given name has been added to this module.
+
+		Important
+		---------
+		This should be used over trying to use :py:meth:`hasattr` on ``m.submodules`` as it will not
+		have the expected results.
+
+		Parameters
+		----------
+		name: str
+			The name of the submodule to look for.
+
+		Returns
+		-------
+		bool
+			If a submodule with the given name exists or not
+		'''
+
+		return name in self._named_submodules


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds a `has_submodule` to the `Module` object to allow for submodule introspection in a way that doesn't rely on the alterations we made to `__getattr__` to better support diagnostics.

This means that all code that was previously using `hasattr(m.submodules, 'foo')` should now be `m.has_submodule('foo')` for the same intended effect.

One thing we might want to do, is possibly look up the callstack inside the `__getattr__`'s on error and if we find a `hasattr` alter the diagnostic to add a note about the new call, but this can be done later.

This closes #139

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
