### PR TITLE
More diagnostics - FSM edition 

### DIFF
--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -856,6 +856,29 @@ class DSLTestCase(ToriiTestSuiteCase):
 			with m.FSM():
 				m.next = 'FOO'
 
+	def test_FSM_unknown_reset(self):
+		m = Module()
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError, (
+				r'^The specified reset state \'IDEL\' did not match any existing states in the FSM '
+				r'\'fsm\', did you mean \'IDLE\'\? \(test_dsl\.py, line \d+\)$'
+			)
+		):
+			with m.FSM(reset = 'IDEL'):
+				with m.State('IDLE'):
+					pass
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError, (
+				r'^The specified reset state \'INVALID\' does not exist inside the FSM \'fsm\' '
+				r'\(test_dsl\.py, line \d+\)$'
+			)
+		):
+			with m.FSM(reset = 'INVALID'):
+				with m.State('IDLE'):
+					pass
+
 	def test_If_inside_FSM_wrong(self):
 		m = Module()
 		with m.FSM():

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -731,13 +731,16 @@ class DSLTestCase(ToriiTestSuiteCase):
 		a = Signal()
 		b = Signal()
 		m = Module()
-		with m.FSM() as fsm:
-			m.d.comb += b.eq(fsm.ongoing('SECOND'))
-			with m.State('FIRST'):
-				pass
-			m.d.comb += a.eq(fsm.ongoing('FIRST'))
-			with m.State('SECOND'):
-				pass
+		with warnings.catch_warnings():
+			warnings.simplefilter('ignore')
+
+			with m.FSM() as fsm:
+				m.d.comb += b.eq(fsm.ongoing('SECOND'))
+				with m.State('FIRST'):
+					pass
+				m.d.comb += a.eq(fsm.ongoing('FIRST'))
+				with m.State('SECOND'):
+					pass
 		m._flush()
 		self.assertEqual(m._generated['fsm'].state.reset, 1)
 		self.maxDiff = 10000
@@ -855,6 +858,22 @@ class DSLTestCase(ToriiTestSuiteCase):
 		):
 			with m.FSM():
 				m.next = 'FOO'
+
+	def test_FSM_unvisited_state(self):
+		m = Module()
+
+		with self.assertWarnsRegex(
+			ToriiSyntaxWarning, (
+				r'^The FSM named \'fsm\' has the following unvisited states: \'UNVISITED\'$'
+			)
+		):
+			with m.FSM():
+				with m.State('IDLE'):
+					m.next = 'VISITED'
+				with m.State('UNVISITED'):
+					pass
+				with m.State('VISITED'):
+					pass
 
 	def test_FSM_unknown_reset(self):
 		m = Module()

--- a/torii/diagnostics/hooks.py
+++ b/torii/diagnostics/hooks.py
@@ -273,24 +273,31 @@ def _warning_handler( # :nocov:
 	'''
 
 	notes: list[str] | None = None
+	additional_ctx: tuple[str, SrcLoc] | None = None
 
 	# Get the output console to write to
 	cons = _get_console(output_file)
 
 	# If `message` is a `Warning` itself, the category is ignored in favor of `message.__class__`
 	# and the message is the stringified object
-	if isinstance(message, Warning):
+	# If the message is a `ToriiWarning` object, then we can treat is specially
+	if isinstance(message, (ToriiWarning, Warning)):
+		# Use the object class as the warning category
 		category = message.__class__
-
-		# If we are in Python 3.11 or newer, then we can have attached notes
 		notes = getattr(message, '__notes__', None)
+
+		if isinstance(message, ToriiWarning):
+			# Pull out the additional context if there is any
+			additional_ctx = getattr(message, 'additional_ctx', None)
+
+		# Stringify the warning to get the message
 		message  = str(message)
 
 	# If the category is `None`, then we need to just say it's a generic warning
 	if category is None:
 		category = Warning
 
-	_render_diagnostic(cons, message, category, filename, lineno, 'yellow', line, notes)
+	_render_diagnostic(cons, message, category, filename, lineno, 'yellow', line, notes, additional_ctx)
 
 def _excepthook(type: type[BaseException], value: BaseException, traceback: TracebackType | None) -> None:
 	'''

--- a/torii/diagnostics/hooks.py
+++ b/torii/diagnostics/hooks.py
@@ -25,7 +25,8 @@ from rich.padding  import Padding
 from rich.panel    import Panel
 from rich.syntax   import Syntax
 
-from ..diagnostics import ToriiError, ToriiSyntaxError
+from .._typing     import SrcLoc
+from ..diagnostics import ToriiError, ToriiWarning, ToriiSyntaxError
 from ..hdl._unused import MustUse
 
 # Create a reference to the handlers that are installed prior to us loading
@@ -172,7 +173,7 @@ def _render_fancy(cons: Console, filename: str, lineno: int, border_style: str, 
 def _render_diagnostic( # :nocov:
 	cons: Console, message: str, category: type[Warning | BaseException], filename: str, lineno: int,
 	accent_color: str, line: str | None = None, notes: list[str] | None = None,
-	additional_ctx: tuple[str, tuple[str, int]] | None = None
+	additional_ctx: tuple[str, SrcLoc] | None = None
 ) -> None:
 
 	# If we want to show the source lines, make sure we can, and it's not the REPL

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -13,6 +13,7 @@ from typing          import TYPE_CHECKING, Any, ParamSpec, TypedDict
 from ..diagnostics   import ToriiSyntaxError, ToriiSyntaxWarning
 from .._typing       import SrcLoc, SwitchCaseT
 from ..util          import _check_name, flatten, tracer
+from ..util.string   import _get_best_matching
 from ..util.units    import bits_for
 from .ast            import (
 	Assign, Cat, Const, Operator, Property, Signal, SignalDict, Statement, Switch, Value, ValueCastT, _StatementList,
@@ -758,6 +759,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if name == 'FSM':
 			if TYPE_CHECKING:
 				assert isinstance(data, _FSMDict)
+			fsm_name = data['name']
 			fsm_signal = data['signal']
 			fsm_reset = data['reset']
 			fsm_encoding = data['encoding']
@@ -769,8 +771,32 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			fsm_signal.width = bits_for(len(fsm_encoding) - 1)
 			if fsm_reset is None:
 				fsm_signal.reset = fsm_encoding[next(iter(fsm_states))]
-			else:
+			elif fsm_reset in fsm_encoding:
 				fsm_signal.reset = fsm_encoding[fsm_reset]
+				# Make sure we remove this state from the unvisited states, as it's our reset state now
+				fsm_unvisited_states -= { fsm_reset }
+			else:
+				src_loc = data['src_loc']
+				matches = _get_best_matching(fsm_reset, fsm_states.keys())
+				additional_ctx = None
+
+				if len(matches) > 0:
+					match = matches[0]
+					message = (
+						f'The specified reset state \'{fsm_reset}\' did not match any existing states in the FSM '
+						f'\'{fsm_name}\', did you mean \'{match}\'?'
+					)
+
+					additional_ctx = (
+						f'The state \'{match}\' was defined here:',
+						fsm_state_src_locs[match]
+					)
+				else:
+					message = f'The specified reset state \'{fsm_reset}\' does not exist inside the FSM \'{fsm_name}\''
+
+				raise ToriiSyntaxError(
+					message = message, src_loc = src_loc, additional_ctx = additional_ctx
+				)
 			# The FSM is encoded such that the state with encoding 0 is always the reset state.
 			fsm_decoding.update((n, s) for s, n in fsm_encoding.items())
 			fsm_signal.decoder = lambda n: f'{fsm_decoding[n]}/{n}'

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -254,6 +254,7 @@ class _FSMDict(TypedDict):
 	states: OrderedDict[str, _StatementList]
 	src_loc: SrcLoc
 	state_src_locs: dict[str, SrcLoc]
+	state_visit_map: dict[str, bool]
 
 _CtrlEntry = _IfDict | _SwitchDict | _FSMDict
 
@@ -624,6 +625,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			'states': OrderedDict(),
 			'src_loc': tracer.get_src_loc(src_loc_at = 1),
 			'state_src_locs': {},
+			'state_visit_map': {},
 		})
 		if TYPE_CHECKING:
 			assert isinstance(fsm_data, _FSMDict)
@@ -670,6 +672,10 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			self._ctrl_context = None
 			yield
 			self._flush_ctrl()
+			if len(fsm_data['states']) == 0 and fsm_data['reset'] is None:
+				# If we are the first state in this FSM /and/ the reset state is not specified then
+				# we are the reset state and are by-default visited
+				fsm_data['state_visit_map'][name] = True
 			fsm_data['states'][name] = self._statements
 			fsm_data['state_src_locs'][name] = src_loc
 		finally:
@@ -697,6 +703,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 						assert isinstance(ctrl_data, _FSMDict)
 					if name not in ctrl_data['encoding']:
 						ctrl_data['encoding'][name] = len(ctrl_data['encoding'])
+					ctrl_data['state_visit_map'][name] = True
 					self._add_statement(
 						assigns    = [ ctrl_data['signal'].eq(ctrl_data['encoding'][name]) ],
 						domain     = ctrl_data['domain'],
@@ -766,6 +773,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			fsm_decoding = data['decoding']
 			fsm_states = data['states']
 			fsm_state_src_locs = data['state_src_locs']
+			fsm_unvisited_states = set(fsm_states.keys()) - set(data['state_visit_map'].keys())
 			if not fsm_states:
 				return
 			fsm_signal.width = bits_for(len(fsm_encoding) - 1)
@@ -811,6 +819,21 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					}
 				)
 			)
+
+			if len(fsm_unvisited_states) > 0:
+				unvisited = ', '.join(map(lambda s: f'\'{s}\'', fsm_unvisited_states))
+
+				warning = ToriiSyntaxWarning(
+					f'The FSM named \'{fsm_name}\' has the following unvisited states: {unvisited}'
+				)
+
+				for state in fsm_unvisited_states:
+					src_loc = fsm_state_src_locs[state]
+					warning.add_note(
+						f'The state \'{state}\' was defined on line {src_loc[1]}'
+					)
+
+				warnings.warn(warning, stacklevel = 4)
 
 	def _add_statement(
 		self, assigns, domain: str, depth, compat_mode = False, domain_loc: tuple[str, int] | None = None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR is yet another in a long long line of Torii diagnostic improvements, this time featuring the beloved FSM.

There are two obvious cases where the FSM should emit a diagnostic, the first being when you try to set the reset state to a state that is not defined in the FSM itself, and the second being when you have "dead" states in the FSM.


The first is easy enough, on FSM finalization, we check to make sure that the `reset` state that was specified exists, and if not, we emit a diagnostic about it. The previous behaviour was to simply explode.

Given the following code below are before/after screenshots:

```py
with m.FSM(reset = 'AWO'):
	with m.State('IDLE'):
		m.d.sync += [
			s.eq(~s)
		]

		with m.If(s):
			m.next = 'FOO'
	with m.State('FOO'):
		m.d.sync += [
			s.eq(0)
		]

	with m.State('AWOO'):
		pass
```


| Before | After |
|--------|-------|
|<img width="1272" height="477" alt="image" src="https://github.com/user-attachments/assets/3f2ce5b8-3059-4e89-b2bb-0a11786b88ee" />|<img width="1269" height="599" alt="image" src="https://github.com/user-attachments/assets/b41fe7e2-4c01-45ba-a31f-8471778c44f3" />|


The second one is a little more tricky, there are several layer at which FSM dead state analysis takes place, but the only one where we have direct enough control over to emit a diagnostic for is when the user explicitly visits the states via `m.next = '...'` inside the FSM, so this does some very **very** rudimentary usage tracking based on that.

<img width="1281" height="331" alt="image" src="https://github.com/user-attachments/assets/bf57c908-b98c-4d5d-a553-a8cce4b90f40" />

There are some important caveats to note about the dead state tracking, due to how the tracking is implemented if there is *any* call to `m.next = 'state'`, even from a state that is not visited, it will count that state as visited.

The tracking for now is simple, but it can be expanded on in the future, in general I think the way to do this would be to have it where we keep track of which states are visited by which other states, we can then find the states that have no visitors, and mark those as dead, then once this is done, take the list of known-dead states and find all the other states who only have the dead states as their visitors, and basically repeat until we can't find any more.

But that's for the future, for now, we get some (slightly) better FSM diagnostics :3

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
