### PR TITLE
Add `Display14SegResource`

### DIFF
--- a/torii/platform/resources/display/__init__.py
+++ b/torii/platform/resources/display/__init__.py
@@ -72,6 +72,104 @@ def Display7SegResource(
 		name_or_number, number, default_name = 'display_7seg', ios = ios, src_loc_at = 1
 	)
 
+def Display14SegResource(
+	name_or_number: str | int, number: int | None = None, *,
+	a: str, b: str, c: str, d: str, e: str, f: str, g: str, h: str, i: str, j: str, k: str, l: str, m: str, # noqa: E741
+	n: str, dp: str | None = None,
+	invert: bool = False, conn: ResourceConn | None = None,
+	attrs: Attrs | None = None
+) -> Resource:
+	'''
+	A 14-segment LED display resource.
+	'''
+
+	ios: list[SubsigArgT] = [
+		Subsignal(
+			'a',
+			Pins(a, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'b',
+			Pins(b, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'c',
+			Pins(c, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'd',
+			Pins(d, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'e',
+			Pins(e, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'f',
+			Pins(f, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'g',
+			Pins(g, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'h',
+			Pins(h, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'i',
+			Pins(i, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'j',
+			Pins(j, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'k',
+			Pins(k, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'l',
+			Pins(l, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'm',
+			Pins(m, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+		Subsignal(
+			'n',
+			Pins(n, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		),
+	]
+
+	if dp is not None:
+		ios.append(Subsignal(
+			'dp',
+			Pins(dp, dir = 'o', invert = invert, conn = conn, assert_width = 1, src_loc_at = 1),
+			src_loc_at = 1
+		))
+
+	if attrs is not None:
+		ios.append(attrs)
+
+	return Resource.family(
+		name_or_number, number, default_name = 'display_14seg', ios = ios, src_loc_at = 1
+	)
+
 def HDMIResource(
 	name_or_number: str | int, number: int | None = None, *,
 	clk_p: str, clk_n: str, d_p: str, d_n: str, scl: str, sda: str,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This is a fairly small and simple PR that just adds a `Display14SegResource` to the `torii.platform.resources.display` module.

We already had a `Display7SegResource`, so this one is a complement for it to support the "Alpha Num" 14-segment displays, like those seen on the Lattice Versa ECP5 dev board, which has been using a raw resource for this.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
