### PR TITLE
torii.back.rtlil: Fixed `Instances` not getting source locality

### DIFF
--- a/torii/back/rtlil.py
+++ b/torii/back/rtlil.py
@@ -971,7 +971,7 @@ def _convert_fragment(builder, fragment, name_map, hierarchy):
 
 			if isinstance(subfragment, ir.Instance):
 				src = _src(subfragment.src_loc)
-			if isinstance(subfragment, mem.MemoryInstance):
+			elif isinstance(subfragment, mem.MemoryInstance):
 				src = _src(subfragment.memory.src_loc)
 			else:
 				src = ''


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

There was small bug in the RTLIL backend that caused us to overwrite source locality information for cell instantiations, this affected anywhere we used `Instance`, which was a lot of places.

The end result was that something like this:
```py
m.submodules.dcca1 = Instance(
	'DCCA',
	i_CE   = Const(1),
	i_CLKI = extref1.i,
	o_CLKO = dcca1_o,
)
```

would generate the following:
```
cell \DCCA \dcca1
  connect \CE 1'1
  connect \CLKI \extref_1__i
  connect \CLKO \dcca1_o
end
```

This is omitting the source information that should normally be present, which has now been fixed causing the generation to have the appropriate attribute, like so:
```
attribute \src "/tmp/meow.py:36"
cell \DCCA \dcca1
  connect \CE 1'1
  connect \CLKI \extref_1__i
  connect \CLKO \dcca1_o
end
```

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
