### PR TITLE
Even More Diagnostics: Emit proper error when trying to use non-castable objects as Torii statements

### DIFF
--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2239,18 +2239,24 @@ class Statement:
 		self.src_loc = tracer.get_src_loc(1 + src_loc_at)
 
 	@staticmethod
-	def cast(obj: Iterable | Statement):
+	def cast(obj: Iterable | Statement, src_loc_at: int = 0):
 		'''
 		.. todo:: Document Me
 		'''
 
-		if isinstance(obj, Iterable):
-			return _StatementList(list(chain.from_iterable(map(Statement.cast, obj))))
+		# Make sure we guard against infinite recursion if we hit a string,
+		if isinstance(obj, Iterable) and not isinstance(obj, str):
+			return _StatementList(
+				list(chain.from_iterable(map(lambda stmt: Statement.cast(stmt, src_loc_at + 2), obj)))
+			)
 		else:
 			if isinstance(obj, Statement):
 				return _StatementList([obj])
 			else:
-				raise TypeError(f'Object {obj!r} is not an Torii statement')
+				raise ToriiSyntaxError(
+					f'The object {obj!r} is not a Torii statement',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
 
 @final
 class Assign(Statement):

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -51,7 +51,9 @@ class _ModuleBuilderDomain(_ModuleBuilderProxy):
 		self._domain = domain
 
 	def __iadd__(self, assigns):
-		self._builder._add_statement(assigns, domain = self._domain, depth = self._depth)
+		self._builder._add_statement(
+			assigns, domain = self._domain, depth = self._depth, src_loc_at = 1
+		)
 		return self
 
 class _ModuleBuilderDomains(_ModuleBuilderProxy):
@@ -836,16 +838,18 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 				warnings.warn(warning, stacklevel = 4)
 
 	def _add_statement(
-		self, assigns, domain: str, depth, compat_mode = False, domain_loc: tuple[str, int] | None = None
+		self, assigns, domain: str, depth, compat_mode = False, domain_loc: tuple[str, int] | None = None,
+		src_loc_at: int = 0
 	):
 		'''
 		.. todo:: Document Me
 		'''
 
-		src_loc = tracer.get_src_loc(1)
 		# Store the very first driving reference
 		if domain not in self._driving_locs:
-			self._driving_locs[domain] = src_loc if domain_loc is None else domain_loc
+			self._driving_locs[domain] = (
+				tracer.get_src_loc(src_loc_at = 1) if domain_loc is None else domain_loc
+			)
 
 		def domain_name(domain):
 			if domain is None:
@@ -856,11 +860,11 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		while len(self._ctrl_stack) > self.domain._depth:
 			self._pop_ctrl()
 
-		for stmt in Statement.cast(assigns):
+		for stmt in Statement.cast(assigns, src_loc_at = src_loc_at + 1):
 			if not compat_mode and not isinstance(stmt, (Assign, Property)):
 				raise ToriiSyntaxError(
 					f'Only assignments and property checks may be appended to d.{domain_name(domain)}',
-					src_loc
+					tracer.get_src_loc(src_loc_at = 1)
 				)
 
 			stmt._MustUse__used = True
@@ -875,7 +879,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 						f'Driver-driver conflict: trying to drive {signal!r} from clock domain '
 						f'\'{domain_name(domain)}\', but it is already driven from the clock domain '
 						f'\'{domain_name(cd_curr)}\'',
-						src_loc
+						tracer.get_src_loc(src_loc_at = 1)
 					)
 
 			self._statements.append(stmt)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This is a fairly simple PR that improves the diagnostics when the user tries to use an object that is not castable to a Torii statement. 

It's fairly thin at the moment, but in the future we might be able to give additional hits/a better message if we spend the effort to figure out what the user gave to us.

Either way, it's an improvement~

| Old | New |
|-|-|
|<img width="1294" height="548" alt="image" src="https://github.com/user-attachments/assets/a94d4b27-ce1d-4251-98c7-0ceea3206dfe" />|<img width="1271" height="305" alt="image" src="https://github.com/user-attachments/assets/c320d915-781d-4815-a296-917febc299c8" />|

This *also* fixes an oversight that would cause stack exhaustion if the invalid castable happens to be a string. It's caused by our flattening code iterating over the string, which will return sub-strings, and that continues forever.

| Old | New |
|-|-|
|<img width="1276" height="717" alt="image" src="https://github.com/user-attachments/assets/a83b5562-1091-4812-8ec8-c91c4ddef3fc" />|<img width="1280" height="312" alt="image" src="https://github.com/user-attachments/assets/80ca2973-0a78-4802-9153-5f85918fde21" />|

There are a few other places where `Statement.cast` is used and should have the `src_loc_at` adjusted, but i've not ran into them, and I think it's fine to tackle it as they come up,

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
