### PR TITLE
Add new `execute_container` on `BuildPlan`, deprecating `execute_docker`

### DIFF
--- a/torii/build/run.py
+++ b/torii/build/run.py
@@ -274,7 +274,12 @@ class BuildPlan:
 			engine, 'run', *args, *env_vars, '--rm',
 			'-v', f'"{build_dir}:{mount}"', '--workdir', mount,
 			image,
-			'sh', f'{self.script}.sh'
+			# XXX(aki):
+			# Some container images might explicitly override where things end up due to having a
+			# `cd` inside an entrypoint wrapper script, in this case we can't guarantee that we will
+			# end up with our cwd set to be the specified working dir, so by explicitly invoking the
+			# command `cd $MOUNT && sh $BUILD_SCRIPT.sh` we ensure we are in the proper location
+			'sh', '-c', f'cd {mount} && sh {self.script}.sh'
 		])
 
 		return LocalBuildProducts(build_dir)

--- a/torii/build/run.py
+++ b/torii/build/run.py
@@ -206,6 +206,29 @@ class BuildPlan:
 		This works by mounting the Torii build root inside of the container and then
 		executing the build script inside of the container.
 
+		Example
+		-------
+		.. code-block:: python
+
+			plan = XilinxPlatform().build(my_module, do_build = False)
+
+			plan.execute_container(
+				image = 'xilinx:vivado-2025.1',
+				engine = 'podman',
+				args = [
+					'--network', 'none'
+				],
+			)
+
+		Important
+		---------
+		When passing ``do_build = False`` to a :py:class:`Platform <torii.build.plat.Platform>`'s
+		:py:meth:`build <torii.build.plat.Platform>` method, all initial runtime checks for tools are skipped, as the
+		tooling is likely not on the host system.
+
+		This also however, means, we can not, and do not validate that the given container has all the required tooling
+		for the platform, meaning the feedback delay between invoking the build and it erroring out is increased.
+
 		Arguments
 		---------
 		image: str
@@ -226,6 +249,17 @@ class BuildPlan:
 		env: dict[str, str]
 			Additional environment variables to set inside of the container
 
+			For example:
+
+			.. code-block:: python
+
+				plan.execute_container(
+					image = 'lattice:diamond-3.14',
+					env = {
+						'DISPLAY': ':0',
+						'XAUTHORITY': '/tmp/.Xauthority'
+					}
+				)
 		Returns
 		-------
 		LocalBuildProduct

--- a/torii/build/run.py
+++ b/torii/build/run.py
@@ -2,19 +2,20 @@
 
 from __future__      import annotations
 
-import hashlib
 import os
-import subprocess
-import sys
-import tarfile
-import zipfile
 from abc             import ABCMeta, abstractmethod
 from collections     import OrderedDict
 from collections.abc import Generator
 from contextlib      import contextmanager
+from hashlib         import blake2b
 from pathlib         import Path
+from subprocess      import check_call
+from sys             import platform
+from tarfile         import TarFile, TarInfo
 from tempfile        import NamedTemporaryFile, _TemporaryFileWrapper
 from typing          import Literal
+from warnings        import warn
+from zipfile         import ZipFile, ZipInfo
 
 __all__ = (
 	'BuildPlan',
@@ -62,7 +63,7 @@ class BuildPlan:
 			The :py:class:`blake2b <hashlib.blake2b>` digest of this build plan.
 		'''
 
-		hasher = hashlib.blake2b(digest_size = size)
+		hasher = blake2b(digest_size = size)
 		for filename in sorted(self.files):
 			hasher.update(filename.encode('utf-8'))
 			content = self.files[filename]
@@ -86,8 +87,8 @@ class BuildPlan:
 		'''
 
 		_archive_types = {
-			'zip': (zipfile.ZipFile, zipfile.ZipInfo, 'w',    '.zip'   ),
-			'tar': (tarfile.TarFile, tarfile.TarInfo, 'w:xz', '.tar.xz')
+			'zip': (ZipFile, ZipInfo, 'w',    '.zip'   ),
+			'tar': (TarFile, TarInfo, 'w:xz', '.tar.xz')
 		}
 
 		if archive_type not in ('tar', 'zip'):
@@ -142,7 +143,7 @@ class BuildPlan:
 					f.write(content)
 
 				# If we're on unix-like and we're emitting the shell script, set it as +x
-				if not sys.platform.startswith('win32') and file.suffix == '.sh':
+				if not platform.startswith('win32') and file.suffix == '.sh':
 					file.chmod(0o755) # rwxr-xr-x
 			return root
 		finally:
@@ -167,17 +168,17 @@ class BuildPlan:
 		script_env = dict(os.environ)
 		if env is not None:
 			script_env.update(env)
-		if sys.platform.startswith('win32'):
+		if platform.startswith('win32'):
 			# Without "call", "cmd /c {}.bat" will return 0.
 			# See https://stackoverflow.com/a/30736987 for a detailed explanation of why.
 			# Running the script manually from a command prompt is unaffected.
-			subprocess.check_call(
+			check_call(
 				[ 'cmd', '/c', f'call {self.script}.bat' ],
 				env = script_env,
 				cwd = build_dir
 			)
 		else:
-			subprocess.check_call(
+			check_call(
 				[ 'sh', f'{self.script}.sh' ],
 				env = script_env,
 				cwd = build_dir
@@ -192,6 +193,57 @@ class BuildPlan:
 		'''
 
 		return self.execute_local()
+
+	def execute_container(
+			self, image: str, root: str | Path = 'build', engine: Literal['docker'] | Literal['podman'] = 'podman',
+			mount: str = '/torii', args: list[str] = list(), env: dict[str, str] = dict()
+	) -> LocalBuildProducts:
+		'''
+		Execute this build plan inside of an ephemeral container.
+
+		Currently two container engines are supported, ``docker`` and ``podman``.
+
+		This works by mounting the Torii build root inside of the container and then
+		executing the build script inside of the container.
+
+		Arguments
+		---------
+		image: str
+			The container image to use
+
+		root: str | Path
+			The Torii build root to use
+
+		engine: Literal['docker'] | Literal['podman']
+			The container engine to use
+
+		mount: str
+			The mount point inside of the Torii build root inside the container
+
+		args: list[str]
+			Additional arguments to pass to the container engine
+
+		env: dict[str, str]
+			Additional environment variables to set inside of the container
+
+		Returns
+		-------
+		LocalBuildProduct
+			The results of the build
+		'''
+
+		build_dir = self.extract(root)
+
+		env_vars: list[str] = [ f'-e=\'{var}={val}\'' for (var, val) in env.items() ]
+
+		check_call([
+			engine, 'run', *args, *env_vars, '--rm',
+			'-v', f'"{build_dir}:{mount}"', '--workdir', mount,
+			image,
+			'sh', f'{self.script}.sh'
+		])
+
+		return LocalBuildProducts(build_dir)
 
 	def execute_docker(
 		self, image: str, root: str | Path = 'root', docker_mount: str = '/build', docker_args: list[str] = []
@@ -224,17 +276,15 @@ class BuildPlan:
 
 		'''
 
-		build_dir = self.extract(root)
+		warn(
+			'The \'execute_docker\' method has been deprecated, please use \'execute_container\' instead',
+			DeprecationWarning,
+			stacklevel = 2
+		)
 
-		subprocess.check_call([
-			'docker', 'run', *docker_args,
-			'--rm', '-v', f'"{build_dir}":{docker_mount}',
-			'--workdir', f'{docker_mount}',
-			image,
-			'sh', f'{self.script}.sh'
-		])
-
-		return LocalBuildProducts(build_dir)
+		return self.execute_container(
+			image, root, 'docker', docker_mount, docker_args
+		)
 
 class BuildProducts(metaclass = ABCMeta):
 	'''

--- a/torii/build/run.py
+++ b/torii/build/run.py
@@ -196,7 +196,8 @@ class BuildPlan:
 
 	def execute_container(
 			self, image: str, root: str | Path = 'build', engine: Literal['docker'] | Literal['podman'] = 'podman',
-			mount: str = '/torii', args: list[str] = list(), env: dict[str, str] = dict()
+			mount: str = '/build', args: list[str] = list(), env: dict[str, str] = dict(),
+			volumes: dict[str, str] = dict(),
 	) -> LocalBuildProducts:
 		'''
 		Execute this build plan inside of an ephemeral container.
@@ -260,6 +261,26 @@ class BuildPlan:
 						'XAUTHORITY': '/tmp/.Xauthority'
 					}
 				)
+
+		volumes: dict[str, str]
+			Additional volumes to mount inside the container
+
+			If you wish to explicitly make the volume read-only, then add ':ro' to the destination
+			mount for the volume, for example:
+
+			.. code-block:: python
+
+				plan.execute_container(
+					image = 'lattice:diamond-3.14',
+					env = {
+						'DISPLAY': ':0',
+						'XAUTHORITY': '/tmp/.Xauthority'
+					},
+					volumes = {
+						'/tmp/.X11-unix': '/tmp/.X11-unix:ro'
+					}
+				)
+
 		Returns
 		-------
 		LocalBuildProduct
@@ -268,11 +289,15 @@ class BuildPlan:
 
 		build_dir = self.extract(root)
 
-		env_vars: list[str] = [ f'-e=\'{var}={val}\'' for (var, val) in env.items() ]
+		env_vars: list[str] = [ f'-e={var}={val}' for (var, val) in env.items() ]
+		ext_volumes: list[str] = [ f'-v={src}:{dst}' for (src, dst) in volumes.items() ]
 
 		check_call([
-			engine, 'run', *args, *env_vars, '--rm',
-			'-v', f'"{build_dir}:{mount}"', '--workdir', mount,
+			engine, 'run', '--rm', f'-w={mount}',
+			*args,
+			*env_vars,
+			'-v', f'{build_dir}:{mount}',
+			*ext_volumes,
 			image,
 			# XXX(aki):
 			# Some container images might explicitly override where things end up due to having a


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds a new method `execute_container` on the `BuildPlan` object. It supersedes the `execute_docker` command, as it's both better defined, and also allows for us to add support for other container engines in the future and not need to have a dozen explicit methods for it.

For now `podman` is the default engine, but changing it is not a huge deal.


An example of it's usage is as follows:

```python
from torii_boards.test.blinky  import Blinky
from torii_boards.lattice.ecp5 import VersaECP55GPlatform

plan = VersaECP55GPlatform(toolchain = 'Diamond').build(Blinky(), verbose = True, do_build = False)

producs = plan.execute_container(
	image  = 'diamond:3.14',
	engine = 'podman',
	args= [
		'--network', 'none'
	],
	env = {
		'DISPLAY': ':0',
	},
	volumes= {
		'/lscc/diamond/3.14': '/opt/lattice/3.14:ro',
	}
)
```

The results of the build are accessible via a `BuildProducts` like they would be from the normal call to `.build` or from `execute_local` on the build plan.

# Pull Request Checklist
<!-- These are *required* -->

* [x] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
