### PR TITLE
Diagnostics Improvements: `torii.hdl.ast`

### DIFF
--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -275,8 +275,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 		c = Const(0)
 		self.assertIs(Value.cast(c), c)
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Object \'str\' cannot be converted to a Torii value$'
+			ToriiSyntaxError,
+			r'^Object \'str\' cannot be converted to a Torii value \(test_ast\.py, line \d+\)$'
 		):
 			Value.cast('str')
 
@@ -303,8 +303,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_bool(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Attempted to convert Torii value to Python boolean$'
+			ToriiSyntaxError,
+			r'^Attempted to convert Torii value to Python boolean \(test_ast\.py, line \d+\)$'
 		):
 			if Const(0):
 				pass
@@ -416,8 +416,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_shift_left_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Shift amount must be an integer, not \'str\'$'
+			ToriiSyntaxError,
+			r'^Shift amount must be an integer, not \'str\' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31).shift_left('str')
 
@@ -483,8 +483,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_shift_right_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Shift amount must be an integer, not \'str\'$'
+			ToriiSyntaxError,
+			r'^Shift amount must be an integer, not \'str\' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31).shift_left('str')
 
@@ -516,8 +516,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_rotate_left_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Rotate amount must be an integer, not \'str\'$'
+			ToriiSyntaxError,
+			r'^Rotate amount must be an integer, not \'str\' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31).rotate_left('str')
 
@@ -549,8 +549,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_rotate_right_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Rotate amount must be an integer, not \'str\'$'
+			ToriiSyntaxError,
+			r'^Rotate amount must be an integer, not \'str\' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31).rotate_right('str')
 
@@ -562,9 +562,16 @@ class ValueTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s2.shape(), unsigned(0))
 
 	def test_replicate_count_wrong(self):
-		with self.assertRaises(TypeError):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Replication count must be a non-zero positive integer, not -1 \(test_ast\.py, line \d+\)$'
+		):
 			Const(10).replicate(-1)
-		with self.assertRaises(TypeError):
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Replication count must be a non-zero positive integer, not \'str\' \(test_ast\.py, line \d+\)$'
+		):
 			Const(10).replicate('str')
 
 	def test_replicate_repr(self):
@@ -685,12 +692,17 @@ class OperatorTestCase(ToriiTestSuiteCase):
 
 	def test_as_signed_wrong(self):
 		with self.assertRaisesRegex(
-			ValueError, r'^Cannot create a 0-width signed value$'
+			ToriiSyntaxError,
+			r'^Cannot create a 0-width signed value \(test_ast\.py, line \d+\)$'
 		):
 			Const(0, 0).as_signed()
 
 	def test_pos(self):
-		self.assertRepr(+Const(10), '(const 4\'d10)')
+		with self.assertWarns(
+			ToriiSyntaxWarning,
+			msg = 'The unary + operator has no effect on Torii values'
+		):
+			self.assertRepr(+Const(10), '(const 4\'d10)')
 
 	def test_neg(self):
 		v1 = -Const(0, unsigned(4))
@@ -761,6 +773,25 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		v5 = 10 // Const(0, 4)
 		self.assertEqual(v5.shape(), unsigned(4))
 
+	def test_trudiv(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Only flooring/integer division \(\'//\'\) is supported on Torii values \(test_ast\.py, line \d+\)$'
+		):
+			_ = Const(0) / Const(1)
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Only flooring/integer division \(\'//\'\) is supported on Torii values \(test_ast\.py, line \d+\)$'
+		):
+			_ = 1 / Const(1)
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Only flooring/integer division \(\'//\'\) is supported on Torii values \(test_ast\.py, line \d+\)$'
+		):
+			_ = Const(0) / 1
+
 	def test_and(self):
 		v1 = Const(0, unsigned(4)) & Const(0, unsigned(6))
 		self.assertEqual(repr(v1), '(& (const 4\'d0) (const 6\'d0))')
@@ -806,9 +837,16 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		self.assertEqual(v1.shape(), unsigned(11))
 
 	def test_shl_wrong(self):
-		with self.assertRaisesRegex(TypeError, r'^Shift amount must be unsigned$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Shift amount must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			1 << Const(0, signed(6))
-		with self.assertRaisesRegex(TypeError, r'^Shift amount must be unsigned$'):
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Shift amount must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			Const(1, unsigned(4)) << -1
 
 	def test_shr(self):
@@ -817,9 +855,16 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		self.assertEqual(v1.shape(), unsigned(4))
 
 	def test_shr_wrong(self):
-		with self.assertRaisesRegex(TypeError, r'^Shift amount must be unsigned$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Shift amount must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			1 << Const(0, signed(6))
-		with self.assertRaisesRegex(TypeError, r'^Shift amount must be unsigned$'):
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Shift amount must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			Const(1, unsigned(4)) << -1
 
 	def test_lt(self):
@@ -971,7 +1016,10 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		self.assertEqual(abs(s).shape(), unsigned(4))
 
 	def test_contains(self):
-		with self.assertRaises(TypeError, msg = 'The python `in` operator is not supported on Torii values'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The python `in` operator is not supported on Torii values \(test_ast\.py, line \d+\)$',
+		):
 			1 in Signal(3)
 
 class SliceTestCase(ToriiTestSuiteCase):
@@ -1142,8 +1190,8 @@ class CatTestCase(ToriiTestSuiteCase):
 
 	def test_str_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Object \'foo\' cannot be converted to a Torii value$'
+			ToriiSyntaxError,
+			r'^Object \'foo\' cannot be converted to a Torii value \(test_ast\.py, line \d+\)$'
 		):
 			Cat('foo')
 
@@ -1687,8 +1735,8 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 		vc = MockValueCastable(None)
 		vc.dest = vc
 		with self.assertRaisesRegex(
-			RecursionError,
-			r'^Value-castable object <.+> casts to itself$'
+			ToriiSyntaxError,
+			r'^Value-castable object <.+> casts to itself \(test_ast\.py, line \d+\)$'
 		):
 			Value.cast(vc)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1537,7 +1537,10 @@ class SignalTestCase(ToriiTestSuiteCase):
 
 	def test_const_wrong(self):
 		s1 = Signal()
-		with self.assertRaises(TypeError, msg = 'Value (sig s1) cannot be converted to a Torii constant'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Value \(sig s1\) cannot be converted to a Torii constant \(test_ast\.py, line \d+\)$'
+		):
 			Const.cast(s1)
 
 class ClockSignalTestCase(ToriiTestSuiteCase):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1649,7 +1649,7 @@ class MockValueCastable(ValueCastable):
 	def __init__(self, dest) -> None:
 		self.dest = dest
 
-	def shape(self):
+	def shape(self, *, src_loc_at: int = 0):
 		return Value.cast(self.dest).shape()
 
 	@ValueCastable.lowermethod
@@ -1660,7 +1660,7 @@ class MockValueCastableChanges(ValueCastable):
 	def __init__(self, width = 0) -> None:
 		self.width = width
 
-	def shape(self):
+	def shape(self, *, src_loc_at: int = 0):
 		return unsigned(self.width)
 
 	@ValueCastable.lowermethod
@@ -1671,7 +1671,7 @@ class MockValueCastableCustomGetattr(ValueCastable):
 	def __init__(self) -> None:
 		pass
 
-	def shape(self):
+	def shape(self, *, src_loc_at: int = 0):
 		raise AssertionError(False)
 
 	@ValueCastable.lowermethod
@@ -1692,7 +1692,7 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 				def __init__(self) -> None:
 					pass # :nocov:
 
-				def shape(self):
+				def shape(self, *, src_loc_at: int = 0):
 					pass # :nocov:
 
 				def as_value(self):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1308,18 +1308,23 @@ class ArrayTestCase(ToriiTestSuiteCase):
 		a[s1]
 		a[s2]
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Array can no longer be mutated after it was indexed with a value at '
+			ToriiSyntaxError,
+			r'^Array mutation is no longer safe in Python code after access by a Torii value'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			a[1] = 2
+
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Array can no longer be mutated after it was indexed with a value at '
+			ToriiSyntaxError,
+			r'^Array mutation is no longer safe in Python code after access by a Torii value'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			del a[1]
+
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Array can no longer be mutated after it was indexed with a value at '
+			ToriiSyntaxError,
+			r'^Array mutation is no longer safe in Python code after access by a Torii value'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			a.insert(1, 2)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -659,6 +659,9 @@ class ConstTestCase(ToriiTestSuiteCase):
 		self.assertIsInstance(s, MockConstValue)
 		self.assertEqual(s.value, 10)
 
+	def test_source_locality(self) -> None:
+		self.assertSrcLoc(Const(0))
+
 class OperatorTestCase(ToriiTestSuiteCase):
 	def test_bool(self):
 		v = Const(0, 4).bool()

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -2168,21 +2168,21 @@ class SampleTestCase(ToriiTestSuiteCase):
 	def test_name_wrong(self):
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Sample domain name must not be empty or contain any control or whitespace characters '
+			r'^Sample domain names may not be empty or contain any control or whitespace characters '
 			r'\(test_ast\.py, line \d+\)$'
 		):
 			Sample(Signal(), 1, domain = '')
 
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Sample domain name must not be empty or contain any control or whitespace characters '
+			r'^Sample domain names may not be empty or contain any control or whitespace characters '
 			r'\(test_ast\.py, line \d+\)$'
 		):
 			Sample(Signal(), 1, domain = ' ')
 
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Sample domain name must not be empty or contain any control or whitespace characters '
+			r'^Sample domain names may not be empty or contain any control or whitespace characters '
 			r'\(test_ast\.py, line \d+\)$'
 		):
 			Sample(Signal(), 1, domain = '\x15')

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1488,8 +1488,8 @@ class ClockSignalTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s2.domain, 'pix')
 
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Clock domain name must be a string, not 1$'
+			ToriiSyntaxError,
+			r'^The domain name for this clock signal must be a string, not 1 \(test_ast\.py, line \d+\)$'
 		):
 			ClockSignal(1)
 
@@ -1504,27 +1504,30 @@ class ClockSignalTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_name_comb(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Domain \'comb\' does not have a clock$'
+			ToriiSyntaxError,
+			r'^The combinatorial logic domain \'comb\' does not have a clock \(test_ast\.py, line \d+\)$'
 		):
 			ClockSignal('comb')
 
 	def test_name_wrong(self):
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this clock signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ClockSignal('')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this clock signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ClockSignal(' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this clock signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ClockSignal('\u0006')
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1536,8 +1536,8 @@ class ResetSignalTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s2.domain, 'pix')
 
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Clock domain name must be a string, not 1$'
+			ToriiSyntaxError,
+			r'^The domain name for this reset signal must be a string, not 1 \(test_ast\.py, line \d+\)$'
 		):
 			ResetSignal(1)
 
@@ -1552,27 +1552,30 @@ class ResetSignalTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_name_comb(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Domain \'comb\' does not have a reset$'
+			ToriiSyntaxError,
+			r'^The combinatorial logic domain \'comb\' does not have a reset \(test_ast\.py, line \d+\)$'
 		):
 			ResetSignal('comb')
 
 	def test_name_wrong(self):
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this reset signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ResetSignal('')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this reset signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ResetSignal(' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The domain name for this reset signal must not be empty or contain any control or whitespace'
+			r' characters \(test_ast\.py, line \d+\)$'
 		):
 			ResetSignal('\u0006')
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1810,7 +1810,10 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 
 class ValueLikeTestCase(ToriiTestSuiteCase):
 	def test_construct(self):
-		with self.assertRaises(TypeError):
+		with self.assertRaisesRegex(
+			ToriiError,
+			r'^The class \'ValueLike\' is an abstract class and cannot be directly constructed$'
+		):
 			ValueLike()
 
 	def test_subclass(self):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -6,7 +6,7 @@ from sys               import version_info
 
 from torii.diagnostics import ToriiSyntaxError, ToriiSyntaxWarning
 from torii.hdl.ast     import (
-	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Part, Past, Property, ResetSignal, Rose, Sample,
+	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Operator, Part, Past, Property, ResetSignal, Rose, Sample,
 	Shape, ShapeCastable, ShapeLike, Signal, Slice, Stable, Switch, Value, ValueCastable, ValueLike,
 	signed, unsigned,
 )
@@ -849,6 +849,13 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		):
 			Const(1, unsigned(4)) << -1
 
+	def test_shl_wrong_impl(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The shift amount operand for the << operator must be unsigned \(test_ast\.py, line \d+\)$',
+		):
+			Operator('<<', (Const(5), Const(1, signed(1)))).shape()
+
 	def test_shr(self):
 		v1 = Const(1, 4) >> Const(4)
 		self.assertEqual(repr(v1), '(>> (const 4\'d1) (const 3\'d4))')
@@ -866,6 +873,13 @@ class OperatorTestCase(ToriiTestSuiteCase):
 			r'^Shift amount must be unsigned \(test_ast\.py, line \d+\)$'
 		):
 			Const(1, unsigned(4)) << -1
+
+	def test_shr_wrong_impl(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The shift amount operand for the >> operator must be unsigned \(test_ast\.py, line \d+\)$',
+		):
+			Operator('>>', (Const(5), Const(1, signed(1)))).shape()
 
 	def test_lt(self):
 		v = Const(0, 4) < Const(0, 6)
@@ -1021,6 +1035,13 @@ class OperatorTestCase(ToriiTestSuiteCase):
 			r'^The python `in` operator is not supported on Torii values \(test_ast\.py, line \d+\)$',
 		):
 			1 in Signal(3)
+
+	def test_nonexistent_operator(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The operator \'#\' with 1 operands does not exist \(test_ast\.py, line \d+\)$'
+		):
+			Operator('#', Const(0)).shape()
 
 class SliceTestCase(ToriiTestSuiteCase):
 	def test_shape(self):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1427,24 +1427,30 @@ class SignalTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s2.name, 'sig')
 
 	def test_name_wrong(self):
-		with self.assertRaisesRegex(TypeError, r'^Name must be a string, not 1$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Signal names must be a string, not 1 \(test_ast\.py, line \d+\)$'
+		):
 			Signal(name = 1)
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Signal name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Signal names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Signal(name = '')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Signal name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Signal names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Signal(name = ' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Signal name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Signal names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Signal(name = '\u0006')
 
@@ -1457,9 +1463,9 @@ class SignalTestCase(ToriiTestSuiteCase):
 		s1 = Signal(2, reset = UnsignedEnum.BAR)
 		self.assertEqual(s1.reset, 2)
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Reset value must be a constant-castable expression, '
-			r'not <StringEnum\.FOO: \'a\'>$'
+			ToriiSyntaxError,
+			r'^The reset value for the signal \'\$signal\' must be a constant-castable expression, not'
+			r' <StringEnum\.FOO: \'a\'> \(test_ast\.py, line \d+\)$'
 		):
 			Signal(1, reset = StringEnum.FOO)
 
@@ -1475,61 +1481,65 @@ class SignalTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s1.reset, 0xaa)
 
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Constant returned by <.+?CastableFromHex.+?>\.const\(\) must have the shape '
-			r'that it casts to, unsigned\(8\), and not unsigned\(1\)$'
+			ToriiSyntaxError,
+			r'^The reset value for the signal \'\$signal\' has different const and non-const shapes'
+			r' \(test_ast\.py, line \d+\)$'
 		):
-			Signal(CastableFromHex(), reset="01")
+			Signal(CastableFromHex(), reset = '01')
 
 	def test_reset_signed_mismatch(self):
 		with self.assertWarnsRegex(
 			ToriiSyntaxWarning,
-			r'^Reset value -2 is signed, but the signal shape is unsigned\(2\)$'
+			r'^The reset value for \'\$signal\' is signed while the signal itself is unsigned$'
 		):
 			Signal(unsigned(2), reset = -2)
 
 	def test_reset_wrong_too_wide(self):
 		with self.assertWarnsRegex(
 			ToriiSyntaxWarning,
-			r'^^Reset value 2 will be truncated to the signal shape unsigned\(1\)$'
+			r'^The reset value for the signal \'\$signal\' will be truncated to match its width$'
 		):
 			Signal(unsigned(1), reset = 2)
+
 		with self.assertWarnsRegex(
 			ToriiSyntaxWarning,
-			r'^Reset value 1 will be truncated to the signal shape signed\(1\)$'
+			r'^The reset value for the signal \'\$signal\' will be truncated to match its width$'
 		):
 			Signal(signed(1), reset = 1)
+
 		with self.assertWarnsRegex(
 			ToriiSyntaxWarning,
-			r'^Reset value -2 will be truncated to the signal shape signed\(1\)$'
+			r'^The reset value for the signal \'\$signal\' will be truncated to match its width$'
 		):
 			Signal(signed(1), reset = -2)
 
 	def test_reset_wrong_fencepost(self):
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Reset value 10 equals the non-inclusive end of the signal shape '
-			r'range\(0, 10\); this is likely an off-by-one error$'
+			ToriiSyntaxError,
+			r'^The reset value 10 for the signal \'\$signal\' is equal to the non-inclusive end of the signal width;'
+			r' this is very likely an off-by-one error \(test_ast\.py, line \d+\)$'
 		):
 			Signal(range(0, 10), reset = 10)
 
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Reset value 0 equals the non-inclusive end of the signal shape '
-			r'range\(0, 0\); this is likely an off-by-one error$'
+			ToriiSyntaxError,
+			r'^The reset value 0 for the signal \'\$signal\' is equal to the non-inclusive end of the signal width;'
+			r' this is very likely an off-by-one error \(test_ast\.py, line \d+\)$'
 		):
 			Signal(range(0), reset = 0)
 
 	def test_reset_wrong_range(self):
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Reset value 11 is not within the signal shape range\(0, 10\)$'
+			ToriiSyntaxError,
+			r'^The reset value 11 falls outside the valid range for the signal \'\$signal\' \[0:9\]'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Signal(range(0, 10), reset = 11)
 
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Reset value 0 is not within the signal shape range\(1, 10\)$'
+			ToriiSyntaxError,
+			r'^The reset value 0 falls outside the valid range for the signal \'\$signal\' \[1:9\]'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Signal(range(1, 10), reset = 0)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -2228,6 +2228,26 @@ class SwitchTestCase(ToriiTestSuiteCase):
 		s = Switch(Const(0, 8), {('00001111', 123): []})
 		self.assertEqual(s.cases, {('00001111', '01111011'): []})
 
+	def test_switch_key_wrong(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Only strings, integers, integer backed enums, and tuples thereof can be used as switch keys,'
+			r' not objects of type bytes \(test_ast\.py, line \d+\)$'
+		):
+			Switch(Const(0, 2), {b'': []})
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The width of the test value and the switch keys must be the same \(test_ast\.py, line \d+\)$'
+		):
+			Switch(Const(0, 2), {'00000': []})
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The width of the test value and the switch keys must be the same \(test_ast\.py, line \d+\)$'
+		):
+			Switch(Const(0, 2), {'00': [], '000': []})
+
 class PropertyTestCase(ToriiTestSuiteCase):
 
 	def test_name_wrong(self):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -2234,19 +2234,28 @@ class PropertyTestCase(ToriiTestSuiteCase):
 		Property._MustUse__silence = True
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Property name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Property names must be a string or None, not 0 \(test_ast\.py, line \d+\)$'
+		):
+			Property('assert', Signal(), name = 0)
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Property names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Property('assert', Signal(), name = '')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Property name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Property names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Property('assert', Signal(), name = ' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Property name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^Property names may not be empty or contain any control or whitespace characters'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Property('assert', Signal(), name = '\x18')

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -53,32 +53,32 @@ class ShapeTestCase(ToriiTestSuiteCase):
 
 	def test_make_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Width must be an integer, not \'a\'$'
+			ToriiSyntaxError,
+			r'^The width of a value must be an integer, not \'a\' \(test_ast\.py, line \d+\)$'
 		):
 			Shape('a')
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Width of an unsigned value must be zero or a positive integer, not -1$'
+			ToriiSyntaxError,
+			r'^The width of an unsigned value must be zero or a positive integer, not -1 \(test_ast\.py, line \d+\)$'
 		):
 			Shape(-1, signed = False)
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Width of a signed value must be a positive integer, not 0$'
+			ToriiSyntaxError,
+			r'^The width of a signed value must be a non-zero positive integer, not 0 \(test_ast\.py, line \d+\)$'
 		):
 			Shape(0, signed = True)
 
 	def test_compare_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Shapes may be compared with shape-castable objects, not \'hi\'$'
+			ToriiSyntaxError,
+			r'^Shapes may be compared with shape-castable objects, not \'hi\' \(test_ast\.py, line \d+\)$'
 		):
 			Shape(1, True) == 'hi'
 
 	def test_compare_tuple_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Shapes may be compared with shape-castable objects, not \(2, 3\)$'
+			ToriiSyntaxError,
+			r'^Shapes may be compared with shape-castable objects, not \(2, 3\) \(test_ast\.py, line \d+\)$'
 		):
 			Shape(1, True) == (2, 3)
 
@@ -120,15 +120,15 @@ class ShapeTestCase(ToriiTestSuiteCase):
 
 	def test_cast_int_wrong(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Width of an unsigned value must be zero or a positive integer, not -1$'
+			ToriiSyntaxError,
+			r'^The width of an unsigned value must be zero or a positive integer, not -1 \(test_ast\.py, line \d+\)$'
 		):
 			Shape.cast(-1)
 
 	def test_cast_tuple_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Object \(-1, True\) cannot be converted to a Torii shape$'
+			ToriiSyntaxError,
+			r'^Object \(-1, True\) cannot be converted to a Torii shape \(test_ast\.py, line \d+\)$'
 		):
 			Shape.cast((-1, True))
 
@@ -171,15 +171,16 @@ class ShapeTestCase(ToriiTestSuiteCase):
 
 	def test_cast_enum_bad(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Only enumerations whose members have constant-castable values can be used in Torii code$'
+			ToriiSyntaxError,
+			r'^Only enumerations whose members have constant-castable values can be used in Torii code'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Shape.cast(StringEnum)
 
 	def test_cast_bad(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Object \'foo\' cannot be converted to a Torii shape$'
+			ToriiSyntaxError,
+			r'^Object \'foo\' cannot be converted to a Torii shape \(test_ast\.py, line \d+\)$'
 		):
 			Shape.cast('foo')
 
@@ -218,8 +219,8 @@ class ShapeCastableTestCase(ToriiTestSuiteCase):
 		sc = MockShapeCastable(None)
 		sc.dest = sc
 		with self.assertRaisesRegex(
-			RecursionError,
-			r'^Shape-castable object <.+> casts to itself$'
+			ToriiSyntaxError,
+			r'^Shape-castable object <.+> casts to itself \(test_ast\.py, line \d+\)$'
 		):
 			Shape.cast(sc)
 
@@ -294,8 +295,9 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_cast_enum_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Only enumerations whose members have constant-castable values can be used in Torii code$'
+			ToriiSyntaxError,
+			r'^Only enumerations whose members have constant-castable values can be used in Torii code'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Value.cast(StringEnum.FOO)
 
@@ -602,8 +604,8 @@ class ConstTestCase(ToriiTestSuiteCase):
 
 	def test_shape_wrong(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Width of an unsigned value must be zero or a positive integer, not -1$'
+			ToriiSyntaxError,
+			r'^The width of an unsigned value must be zero or a positive integer, not -1 \(test_ast\.py, line \d+\)$'
 		):
 			Const(1, -1)
 
@@ -1313,8 +1315,8 @@ class SignalTestCase(ToriiTestSuiteCase):
 
 	def test_shape_wrong(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Width of an unsigned value must be zero or a positive integer, not -10$'
+			ToriiSyntaxError,
+			r'^The width of an unsigned value must be zero or a positive integer, not -10 \(test_ast\.py, line \d+\)$'
 		):
 			Signal(-10)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1066,13 +1066,14 @@ class SliceTestCase(ToriiTestSuiteCase):
 
 	def test_start_end_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Slice start must be an integer, not \'x\'$'
+			ToriiSyntaxError,
+			r'^The start index of a Slice must be an integer, not \'x\' \(test_ast\.py, line \d+\)$'
 		):
 			Slice(0, 'x', 1)
+
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Slice stop must be an integer, not \'x\'$'
+			ToriiSyntaxError,
+			r'^The stop index of a Slice must be an integer, not \'x\' \(test_ast\.py, line \d+\)$'
 		):
 			Slice(0, 1, 'x')
 
@@ -1080,27 +1081,31 @@ class SliceTestCase(ToriiTestSuiteCase):
 		c = Const(0, 8)
 		with self.assertRaisesRegex(
 			IndexError,
-			r'^Cannot start slice 10 bits into 8-bit value$'
+			r'^Cannot start slice 10 bits into a\(n\) 8-bit value \(test_ast\.py, line \d+\)$'
 		):
 			Slice(c, 10, 12)
+
 		with self.assertRaisesRegex(
 			IndexError,
-			r'^Cannot stop slice 12 bits into 8-bit value$'
+			r'^Cannot stop slice 12 bits into a\(n\) 8-bit value \(test_ast\.py, line \d+\)$'
 		):
 			Slice(c, 0, 12)
+
 		with self.assertRaisesRegex(
 			IndexError,
-			r'^Slice start 4 must be less than slice stop 2$'
+			r'^Slice start 4 must be less than slice stop 2 \(test_ast\.py, line \d+\)$'
 		):
 			Slice(c, 4, 2)
+
 		with self.assertRaisesRegex(
 			IndexError,
-			r'^Cannot start slice -9 bits into 8-bit value$'
+			r'^Cannot start slice -9 bits into a\(n\) 8-bit value \(test_ast\.py, line \d+\)$'
 		):
 			Slice(c, -9, -5)
+
 		with self.assertRaisesRegex(
 			IndexError,
-			r'^Cannot stop slice 9 bits into 8-bit value$'
+			r'^Cannot stop slice 9 bits into a\(n\) 8-bit value \(test_ast\.py, line \d+\)$'
 		):
 			Slice(c, 5, 9)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -591,6 +591,11 @@ class ValueTestCase(ToriiTestSuiteCase):
 			'(eq (const 1\'d1) (- (const 1\'d1) (const 3\'d4)))'
 		)
 
+	def test_source_locality(self) -> None:
+		self.assertSrcLoc(Const(10)[0])
+		self.assertSrcLoc(Const(10)[0:5])
+		self.assertSrcLoc(Const(10)[0:2:8])
+
 class ConstTestCase(ToriiTestSuiteCase):
 	def test_shape(self):
 		self.assertEqual(Const(0).shape(),   unsigned(1))

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -230,7 +230,10 @@ class ShapeCastableTestCase(ToriiTestSuiteCase):
 
 class ShapeLikeTestCase(ToriiTestSuiteCase):
 	def test_construct(self):
-		with self.assertRaises(TypeError):
+		with self.assertRaisesRegex(
+			ToriiError,
+			r'^The class \'ShapeLike\' is an abstract class and cannot be directly constructed$'
+		):
 			ShapeLike()
 
 	def test_subclass(self):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -626,8 +626,8 @@ class ConstTestCase(ToriiTestSuiteCase):
 	def test_wrong_fencepost(self):
 		with self.assertWarnsRegex(
 			ToriiSyntaxWarning,
-			r'^Value 10 equals the non-inclusive end of the constant shape '
-			r'range\(0, 10\); this is likely an off-by-one error$'
+			r'^The value 10 is equal to the non-inclusive end of the constants width; this is very likely an off-by-one'
+			r' error$'
 		):
 			Const(10, range(10))
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -4,7 +4,7 @@ import warnings
 from enum              import Enum, EnumMeta
 from sys               import version_info
 
-from torii.diagnostics import ToriiSyntaxError, ToriiSyntaxWarning
+from torii.diagnostics import ToriiError, ToriiSyntaxError, ToriiSyntaxWarning
 from torii.hdl.ast     import (
 	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Operator, Part, Past, Property, ResetSignal, Rose, Sample,
 	Shape, ShapeCastable, ShapeLike, Signal, Slice, Stable, Switch, Value, ValueCastable, ValueLike,
@@ -1741,9 +1741,10 @@ class MockValueCastableCustomGetattr(ValueCastable):
 class ValueCastableTestCase(ToriiTestSuiteCase):
 	def test_not_decorated(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Class \'MockValueCastableNotDecorated\' deriving from `ValueCastable` must '
-			r'decorate the `as_value` method with the `ValueCastable.lowermethod` decorator$'
+			ToriiError,
+			r'^The class \'MockValueCastableNotDecorated\' which derives from \'ValueCastable\' must'
+			r' decorate the overridden \'ValueCastable\.as_value\' method with the \'ValueCastable\.lowermethod\''
+			r' decorator$'
 		):
 			class MockValueCastableNotDecorated(ValueCastable):
 				def __init__(self) -> None:
@@ -1757,18 +1758,18 @@ class ValueCastableTestCase(ToriiTestSuiteCase):
 
 	def test_no_override(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Class \'MockValueCastableNoOverrideAsValue\' deriving from `ValueCastable` must '
-			r'override the `as_value` method$'
+			ToriiError,
+			r'^The class \'MockValueCastableNoOverrideAsValue\' which derives from \'ValueCastable\' must'
+			r' provide an override for the \'ValueCastable\.as_value\' method'
 		):
 			class MockValueCastableNoOverrideAsValue(ValueCastable):
 				def __init__(self) -> None:
 					pass # :nocov:
 
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Class \'MockValueCastableNoOverrideShape\' deriving from `ValueCastable` must '
-			r'override the `shape` method$'
+			ToriiError,
+			r'^The class \'MockValueCastableNoOverrideShape\' which derives from \'ValueCastable\' must'
+			r' provide an override for the \'ValueCastable\.shape\' method$'
 		):
 			class MockValueCastableNoOverrideShape(ValueCastable):
 				def __init__(self) -> None:

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -4,7 +4,7 @@ import warnings
 from enum              import Enum, EnumMeta
 from sys               import version_info
 
-from torii.diagnostics import ToriiSyntaxError
+from torii.diagnostics import ToriiSyntaxError, ToriiSyntaxWarning
 from torii.hdl.ast     import (
 	Array, Cat, ClockSignal, Const, Edge, Fell, Initial, Mux, Part, Past, Property, ResetSignal, Rose, Sample,
 	Shape, ShapeCastable, ShapeLike, Signal, Slice, Stable, Switch, Value, ValueCastable, ValueLike,
@@ -609,7 +609,7 @@ class ConstTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_fencepost(self):
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Value 10 equals the non-inclusive end of the constant shape '
 			r'range\(0, 10\); this is likely an off-by-one error$'
 		):
@@ -876,7 +876,7 @@ class OperatorTestCase(ToriiTestSuiteCase):
 	def test_matches(self):
 		s = Signal(4)
 		with self.assertWarns(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			msg = 'Value.matches() with an empty patterns clause will return `Const(0)` in a future release.'
 		):
 			self.assertRepr(s.matches(), '(const 1\'d1)')
@@ -913,7 +913,7 @@ class OperatorTestCase(ToriiTestSuiteCase):
 		):
 			s.matches('--')
 		with self.assertWarnsRegex(
-			SyntaxWarning, (
+			ToriiSyntaxWarning, (
 				r'^Match pattern \'22\' \(5\'10110\) is wider than match value \(which has width 4\); '
 				r'comparison will never be true$'
 			)
@@ -921,7 +921,7 @@ class OperatorTestCase(ToriiTestSuiteCase):
 			s.matches(0b10110)
 
 		with self.assertWarns(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			msg = 'Match pattern \'(cat (const 1\'d0) (const 4\'d11))\' (5\'10110) is wider than match value (which has width 4); comparison will never be true' # noqa: E501
 		):
 			s.matches(Cat(0, Const(0b1011, 4)))
@@ -1137,7 +1137,7 @@ class CatTestCase(ToriiTestSuiteCase):
 
 	def test_int_01(self):
 		with warnings.catch_warnings():
-			warnings.filterwarnings(action = 'error', category = SyntaxWarning)
+			warnings.filterwarnings(action = 'error', category = ToriiSyntaxWarning)
 			Cat(0, 1, 1, 0)
 
 	def test_enum_wrong(self):
@@ -1146,7 +1146,7 @@ class CatTestCase(ToriiTestSuiteCase):
 			BLUE = 2
 
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Argument #1 of \'Cat\(\)\' is an enumerated value <Color\.RED: 1> without '
 			r'a defined shape used in a bit vector context; use \'Const\' to specify '
 			r'the shape\.$',
@@ -1160,7 +1160,7 @@ class CatTestCase(ToriiTestSuiteCase):
 			BLUE = 2
 
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Argument #1 of \'Cat\(\)\' is an enumerated value <Color\.RED: 1> '
 			r'without a defined shape used in a bit vector context; use \'Const\' to specify '
 			r'the shape\.$'
@@ -1171,7 +1171,7 @@ class CatTestCase(ToriiTestSuiteCase):
 
 	def test_int_wrong(self):
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Argument #1 of \'Cat\(\)\' is a bare integer 2 used in bit vector context; '
 			r'consider specifying the width explicitly using \'Const\(2, 2\)\' instead$'
 		):
@@ -1381,24 +1381,24 @@ class SignalTestCase(ToriiTestSuiteCase):
 
 	def test_reset_signed_mismatch(self):
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Reset value -2 is signed, but the signal shape is unsigned\(2\)$'
 		):
 			Signal(unsigned(2), reset = -2)
 
 	def test_reset_wrong_too_wide(self):
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^^Reset value 2 will be truncated to the signal shape unsigned\(1\)$'
 		):
 			Signal(unsigned(1), reset = 2)
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Reset value 1 will be truncated to the signal shape signed\(1\)$'
 		):
 			Signal(signed(1), reset = 1)
 		with self.assertWarnsRegex(
-			SyntaxWarning,
+			ToriiSyntaxWarning,
 			r'^Reset value -2 will be truncated to the signal shape signed\(1\)$'
 		):
 			Signal(signed(1), reset = -2)

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -1148,7 +1148,10 @@ class BitSelectTestCase(ToriiTestSuiteCase):
 		self.assertRepr(s1, '(slice (const 8\'d0) 1:3)')
 
 	def test_width_wrong(self):
-		with self.assertRaises(TypeError):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Part width must be a non-negative integer, not -1 \(test_ast\.py, line \d+\)$'
+		):
 			self.c.bit_select(self.s, -1)
 
 	def test_repr(self):
@@ -1156,7 +1159,10 @@ class BitSelectTestCase(ToriiTestSuiteCase):
 		self.assertEqual(repr(s), '(part (const 8\'d0) (sig s) 2 1)')
 
 	def test_offset_wrong(self):
-		with self.assertRaisesRegex(TypeError, r'^Part offset must be unsigned$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Part offset must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			self.c.bit_select(self.s.as_signed(), 1)
 
 class WordSelectTestCase(ToriiTestSuiteCase):
@@ -1181,9 +1187,16 @@ class WordSelectTestCase(ToriiTestSuiteCase):
 		self.assertRepr(s1, '(slice (const 8\'d0) 2:4)')
 
 	def test_width_wrong(self):
-		with self.assertRaises(TypeError):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Part stride must be a positive non-zero integer, not 0 \(test_ast\.py, line \d+\)$'
+		):
 			self.c.word_select(self.s, 0)
-		with self.assertRaises(TypeError):
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Part width must be a non-negative integer, not -1 \(test_ast\.py, line \d+\)$'
+		):
 			self.c.word_select(self.s, -1)
 
 	def test_repr(self):
@@ -1191,7 +1204,10 @@ class WordSelectTestCase(ToriiTestSuiteCase):
 		self.assertEqual(repr(s), '(part (const 8\'d0) (sig s) 2 2)')
 
 	def test_offset_wrong(self):
-		with self.assertRaisesRegex(TypeError, r'^Part offset must be unsigned$'):
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Part offset must be unsigned \(test_ast\.py, line \d+\)$'
+		):
 			self.c.word_select(self.s.as_signed(), 1)
 
 class CatTestCase(ToriiTestSuiteCase):

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -965,8 +965,8 @@ class OperatorTestCase(ToriiTestSuiteCase):
 	def test_matches_width_wrong(self):
 		s = Signal(4)
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Match pattern \'--\' must have the same width as match value \(which is 4\)$'
+			ToriiSyntaxError,
+			r'^Match pattern \'--\' must have the same width as match value \(which is 4\) \(test_ast\.py, line \d+\)$'
 		):
 			s.matches('--')
 		with self.assertWarnsRegex(
@@ -986,9 +986,9 @@ class OperatorTestCase(ToriiTestSuiteCase):
 	def test_matches_bits_wrong(self):
 		s = Signal(4)
 		with self.assertRaisesRegex(
-			SyntaxError, (
+			ToriiSyntaxError, (
 				r'^Match pattern \'abc\' must consist of 0, 1, and - \(don\'t care\) bits, '
-				r'and may include whitespace$'
+				r'and may include whitespace \(test_ast\.py, line \d+\)$'
 			)
 		):
 			s.matches('abc')
@@ -996,8 +996,8 @@ class OperatorTestCase(ToriiTestSuiteCase):
 	def test_matches_pattern_wrong(self):
 		s = Signal(4)
 		with self.assertRaisesRegex(
-			SyntaxError,
-			r'^Match pattern must be a string or a const-castable expression, not 1\.0$'
+			ToriiSyntaxError,
+			r'^Match pattern must be a string or a const-castable expression, not 1\.0 \(test_ast\.py, line \d+\)$'
 		):
 			s.matches(1.0)
 

--- a/tests/hdl/test_ast.py
+++ b/tests/hdl/test_ast.py
@@ -322,8 +322,8 @@ class ValueTestCase(ToriiTestSuiteCase):
 		self.assertEqual(s2.start, 3)
 		self.assertEqual(s2.stop, 4)
 		with self.assertRaisesRegex(
-			IndexError,
-			r'^Index 5 is out of bounds for a 4-bit value$'
+			ToriiSyntaxError,
+			r'^Index 5 is out of bounds for a 4-bit value \(test_ast\.py, line \d+\)$'
 		):
 			Const(10)[5]
 
@@ -350,21 +350,23 @@ class ValueTestCase(ToriiTestSuiteCase):
 
 	def test_getitem_wrong(self):
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Cannot index value with \'str\'$'
+			ToriiSyntaxError,
+			r'^Cannot index value with \'str\' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31)['str']
 
-		with self.assertRaises(
-			SyntaxError,
-			msg = 'Slicing a value with a Value is unsupported, use `Value.bit_select()` or `Value.word_select()` instead.' # noqa: E501
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Indexing a value with another value is not supported, use `Value\.bit_select\(\)` instead\.'
+			r' \(test_ast\.py, line \d+\)$'
 		):
 			Const(31)[Signal(3)]
 
 		s = Signal(3)
-		with self.assertRaises(
-			SyntaxError,
-			msg = 'Indexing a value with another value is not supported, use `Value.bit_select()` instead.'
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Slicing a value with a Value is unsupported, use `Value\.bit_select\(\)` or `Value\.word_select\(\)` '
+			r'instead\. \(test_ast\.py, line \d+\)$'
 		):
 			Const(31)[s:s + 3]
 

--- a/tests/hdl/test_cd.py
+++ b/tests/hdl/test_cd.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.hdl.cd import ClockDomain
+from torii.diagnostics import ToriiSyntaxError
+from torii.hdl.cd      import ClockDomain
 
-from ..utils      import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
 class ClockDomainTestCase(ToriiTestSuiteCase):
 	def test_name(self):
@@ -20,8 +21,9 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 		dom = [ClockDomain('foo')][0]
 		self.assertEqual(dom.name, 'foo')
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Clock domain name must be specified explicitly$'
+			ToriiSyntaxError,
+			r'^The name for this clock domain could not be automatically determined and no name was'
+			r' explicitly specified \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain()
 		cd_reset = ClockDomain(local = True)
@@ -29,39 +31,45 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 
 	def test_name_wrong(self):
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain(' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('\x14')
 
 	def test_rename_wrong(self):
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('meow').rename('')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('meow').rename(' ')
 
 		with self.assertRaisesRegex(
-			NameError,
-			r'^Clock domain name must not be empty or contain any control or whitespace characters$'
+			ToriiSyntaxError,
+			r'^The name specified for this clock domain must not be empty or contain any control/whitespace'
+			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('meow').rename('\x7F')
 
@@ -75,8 +83,8 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 
 	def test_edge_wrong(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Domain clock edge must be one of \'pos\' or \'neg\', not \'xxx\'$'
+			ToriiSyntaxError,
+			r'^Domain clock edge must be one of \'pos\' or \'neg\', not \'xxx\' \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('sync', clk_edge = 'xxx')
 
@@ -118,7 +126,7 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 
 	def test_wrong_name_comb(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Domain \'comb\' may not be clocked$'
+			ToriiSyntaxError,
+			r'^The combinatorial logic domain \'comb\' may not be clocked \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain(name = 'comb')

--- a/tests/hdl/test_rec.py
+++ b/tests/hdl/test_rec.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from enum          import Enum
+from enum              import Enum
 
-from torii.hdl.ast import Shape, Signal, signed, unsigned
-from torii.hdl.rec import Direction, Layout, Record
+from torii.diagnostics import ToriiSyntaxError
+from torii.hdl.ast     import Shape, Signal, signed, unsigned
+from torii.hdl.rec     import Direction, Layout, Record
 
-from ..utils       import ToriiTestSuiteCase
+from ..utils           import ToriiTestSuiteCase
 
 class UnsignedEnum(Enum):
 	FOO = 1
@@ -282,8 +283,8 @@ class RecordTestCase(ToriiTestSuiteCase):
 
 		# __bool__
 		with self.assertRaisesRegex(
-			TypeError,
-			r'^Attempted to convert Torii value to Python boolean$'
+			ToriiSyntaxError,
+			r'^Attempted to convert Torii value to Python boolean \(test_rec\.py, line \d+\)$'
 		):
 			not r1
 

--- a/tests/hdl/test_xfrm.py
+++ b/tests/hdl/test_xfrm.py
@@ -217,7 +217,7 @@ class DomainLowererTestCase(ToriiTestSuiteCase):
 
 		with self.assertRaisesRegex(
 			DomainError,
-			r'^Signal \(clk xxx\) refers to nonexistent domain \'xxx\'$'
+			r'^The signal \(clk xxx\) refers to nonexistent domain \'xxx\'$'
 		):
 			DomainLowerer()(f)
 

--- a/tests/hdl/test_xfrm.py
+++ b/tests/hdl/test_xfrm.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # torii: UnusedElaboratable=no
 
-from torii.diagnostics import DomainError
+from torii.diagnostics import DomainError, ToriiSyntaxError
 from torii.hdl.ast     import Cat, ClockSignal, ResetSignal, Sample, Signal, SignalSet, Switch
 from torii.hdl.cd      import ClockDomain
 from torii.hdl.dsl     import Module
@@ -132,15 +132,17 @@ class DomainRenamerTestCase(ToriiTestSuiteCase):
 
 	def test_rename_wrong_to_comb(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^Domains may not be renamed to the combinatorial domain \'comb\'$'
+			ToriiSyntaxError,
+			r'^Synchronous logic domains may not be renamed to the combinatorial logic domain \'comb\''
+			r' \(test_xfrm\.py, line \d+\)$'
 		):
 			DomainRenamer(sync = 'comb')
 
 	def test_rename_wrong_from_comb(self):
 		with self.assertRaisesRegex(
-			ValueError,
-			r'^The combinatorial domain \'comb\' may not be renamed to \'sync\'$'
+			ToriiSyntaxError,
+			r'^The combinatorial logic domain \'comb\' may not be renamed to the domain \'sync\''
+			r' \(test_xfrm\.py, line \d+\)$'
 		):
 			DomainRenamer(comb = 'sync')
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,13 +6,14 @@ import shutil
 import subprocess
 import textwrap
 import traceback
-from pathlib       import Path
+from pathlib           import Path
 
-from torii.back    import rtlil
-from torii.hdl.ast import Statement
-from torii.hdl.ir  import Fragment
-from torii.test    import ToriiTestCase
-from torii.tools   import ToolNotFound, require_tool
+from torii.back        import rtlil
+from torii.hdl.ast     import Statement
+from torii.hdl.ir      import Fragment
+from torii.test        import ToriiTestCase
+from torii.tools       import ToolNotFound, require_tool
+from torii.util.tracer import get_src_loc
 
 __all__ = (
 	'ToriiTestSuiteCase',
@@ -106,3 +107,11 @@ class ToriiTestSuiteCase(ToriiTestCase):
 			stdout, stderr = proc.communicate(config)
 			if proc.returncode != 0:
 				self.fail('Formal verification failed:\n' + stdout)
+
+	def assertSrcLoc(self, obj):
+		'''
+		Assert that the given objects `src_loc` matches the call-site for this assert
+		'''
+
+		src_loc = get_src_loc(src_loc_at = 0)
+		self.assertEqual(src_loc, obj.src_loc)

--- a/torii/diagnostics/__init__.py
+++ b/torii/diagnostics/__init__.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from .errors   import (
-	ConstraintError, DomainError, NameError, NameNotFound, NonSynthesizableError, PlatformError, ResourceError,
-	ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
+	ConstraintError, DomainError, IndexError, NameError, NameNotFound, NonSynthesizableError, PlatformError,
+	ResourceError, ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
 )
 from .warnings import (
 	ConstraintWarning, DriverConflict, MustUseWarning, NameWarning, PlatformWarning, ResourceWarning, ToolWarning,
@@ -14,11 +14,14 @@ __all__ = (
 	'ConstraintWarning',
 	'DomainError',
 	'DriverConflict',
+	'IndexError',
 	'MustUseWarning',
 	'NameError',
 	'NameNotFound',
 	'NameWarning',
 	'NonSynthesizableError',
+	'PlatformError',
+	'PlatformWarning',
 	'ResourceError',
 	'ResourceWarning',
 	'ToolError',
@@ -32,6 +35,4 @@ __all__ = (
 	'UnusedProperty',
 	'YosysError',
 	'YosysWarning',
-	'PlatformError',
-	'PlatformWarning',
 )

--- a/torii/diagnostics/errors.py
+++ b/torii/diagnostics/errors.py
@@ -9,6 +9,7 @@ from .._typing import SrcLoc
 __all__ = (
 	'ConstraintError',
 	'DomainError',
+	'IndexError',
 	'NameError',
 	'NameNotFound',
 	'NonSynthesizableError',
@@ -109,4 +110,8 @@ class ResourceError(ToriiError):
 
 class YosysError(ToolError):
 	''' An error when invoking Yosys '''
+	pass
+
+class IndexError(ToriiSyntaxError, IndexError):
+	'''  '''
 	pass

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1170,12 +1170,16 @@ class Const(Value, metaclass = _ConstMeta):
 			shape = Shape(shape, signed = self.value < 0, src_loc_at = 1 + src_loc_at)
 		else:
 			if isinstance(shape, range) and self.value == shape.stop:
-				warnings.warn(
-					f'Value {self.value!r} equals the non-inclusive end of the constant '
-					f'shape {shape!r}; this is likely an off-by-one error',
-					category = ToriiSyntaxWarning,
-					stacklevel = 2 + src_loc_at
+				warning = ToriiSyntaxWarning(
+					f'The value {self.value!r} is equal to the non-inclusive end of the constants width;'
+					' this is very likely an off-by-one error'
 				)
+
+				warning.add_note(
+					f'The constant is {shape.stop - 1} bit(s) wide: [{shape.start}:{shape.stop - 1}]'
+				)
+
+				warnings.warn(warning, stacklevel = 2 + src_loc_at)
 			shape = Shape.cast(shape, src_loc_at = 1 + src_loc_at)
 		self.width  = shape.width
 		self.signed = shape.signed

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1306,7 +1306,7 @@ class Operator(Value):
 	def __repr__(self) -> str:
 		return f'({self.operator} {" ".join(map(repr, self.operands))})'
 
-def Mux(sel: ValueCastT, val1: ValueCastT, val0: ValueCastT) -> Operator:
+def Mux(sel: ValueCastT, val1: ValueCastT, val0: ValueCastT, *, src_loc_at: int = 0) -> Operator:
 	'''
 	Choose between two values.
 
@@ -1325,7 +1325,7 @@ def Mux(sel: ValueCastT, val1: ValueCastT, val0: ValueCastT) -> Operator:
 		Output ``Value``. If ``sel`` is asserted, the Mux returns ``val1``, else ``val0``.
 	'''
 
-	return Operator('m', (sel, val1, val0))
+	return Operator('m', (sel, val1, val0), src_loc_at = src_loc_at)
 
 @final
 class Slice(Value):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -17,7 +17,7 @@ from typing            import (
 	TYPE_CHECKING, Generic, Literal, NoReturn, ParamSpec, SupportsIndex, TypeAlias, TypeVar, TypeVarTuple,
 )
 
-from ..diagnostics     import ToriiSyntaxError, UnusedProperty
+from ..diagnostics     import ToriiSyntaxError, ToriiSyntaxWarning, UnusedProperty
 from .._typing         import SrcLoc, SwitchCaseT
 from ..util            import _check_name, flatten, tracer, union
 from ..util.decorators import final
@@ -709,7 +709,7 @@ class Value(metaclass = ABCMeta):
 					warnings.warn(
 						f'Match pattern \'{pattern}\' ({pattern_len}\'{new_pattern.value:b}) is wider than '
 						f'match value (which has width {len(self)}); comparison will never be true',
-						SyntaxWarning, stacklevel = 2
+						ToriiSyntaxWarning, stacklevel = 2
 					)
 					continue
 				matches.append(self == new_pattern)
@@ -717,7 +717,7 @@ class Value(metaclass = ABCMeta):
 		if not matches:
 			warnings.warn(
 				'Value.matches() with an empty patterns clause will return `Const(0)` in a future release.',
-				SyntaxWarning, stacklevel = 2
+				ToriiSyntaxWarning, stacklevel = 2
 			)
 			return Const(1)
 		elif len(matches) == 1:
@@ -1032,7 +1032,7 @@ class Const(Value, metaclass = _ConstMeta):
 				warnings.warn(
 					f'Value {self.value!r} equals the non-inclusive end of the constant '
 					f'shape {shape!r}; this is likely an off-by-one error',
-					category = SyntaxWarning,
+					category = ToriiSyntaxWarning,
 					stacklevel = 3
 				)
 			shape = Shape.cast(shape, src_loc_at = 1 + src_loc_at)
@@ -1287,7 +1287,7 @@ class Cat(Value):
 					f'Argument #{index + 1} of \'Cat()\' is an enumerated value {arg!r} without '
 					'a defined shape used in a bit vector context; use \'Const\' to specify '
 					'the shape.',
-					SyntaxWarning, stacklevel = 2 + src_loc_at
+					ToriiSyntaxWarning, stacklevel = 2 + src_loc_at
 				)
 
 			if isinstance(arg, int) and not isinstance(arg, Enum) and arg not in [0, 1]:
@@ -1295,7 +1295,7 @@ class Cat(Value):
 					f'Argument #{index + 1} of \'Cat()\' is a bare integer {arg} used in bit vector '
 					f'context; consider specifying the width explicitly using \'Const({arg}, {bits_for(arg)})\' '
 					'instead',
-					SyntaxWarning, stacklevel = 2 + src_loc_at
+					ToriiSyntaxWarning, stacklevel = 2 + src_loc_at
 				)
 
 			# NOTE(aki): Type inference is scrambled by the check above, so as painful as it is we ignore it
@@ -1423,7 +1423,7 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 			if reset_val.shape().signed and not self.signed:
 				warnings.warn(
 					message = f'Reset value {reset!r} is signed, but the signal shape is {shape!r}',
-					category = SyntaxWarning,
+					category = ToriiSyntaxWarning,
 					stacklevel = 2
 				)
 			elif (
@@ -1433,7 +1433,7 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 			):
 				warnings.warn(
 					message = f'Reset value {reset!r} will be truncated to the signal shape {shape!r}',
-					category = SyntaxWarning,
+					category = ToriiSyntaxWarning,
 					stacklevel = 2
 				)
 		self.reset = reset_val.value

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2770,7 +2770,10 @@ class Switch(Statement):
 		# be automatically traced, so whatever constructs a Switch may optionally provide it.
 		self.case_src_locs: dict[tuple[str, ...], SrcLoc] = {}
 
-		self.test  = Value.cast(test)
+		# XXX(aki):
+		# As per the note above, this might cause issues with diagnostics reporting if the test value
+		# casting throws a wobbly and we bubble it up the stack...
+		self.test  = Value.cast(test, src_loc_at = 1 + src_loc_at)
 		self.cases = OrderedDict[tuple[str, ...], _StatementList]()
 		for orig_keys, stmts in cases.items():
 			# Map: None -> (); key -> (key,); (key...) -> (key...)
@@ -2795,15 +2798,27 @@ class Switch(Statement):
 					if key_mask == 0:
 						new_key = ''
 				else:
-					raise TypeError(f'Object {key!r} cannot be used as a switch key')
-				if len(new_key) != len(self.test):
-					raise ValueError(
-						f'Length mismatch between switch key and test value {len(new_key)} != {len(self.test)}'
+					raise ToriiSyntaxError(
+						'Only strings, integers, integer backed enums, and tuples thereof can be used as switch keys,'
+						f' not objects of type {type(key).__name__}',
+						self.src_loc
 					)
+
+				if len(new_key) != len(self.test):
+					raise ToriiSyntaxError(
+						'The width of the test value and the switch keys must be the same',
+						self.src_loc,
+						notes = [
+							f'The test value has a width of {len(self.test)} where as the switch key \'{new_key}\''
+							f' has the width of {len(new_key)}'
+						]
+					)
+
 				new_keys = (*new_keys, new_key)
 			if not isinstance(stmts, Iterable):
 				stmts = [stmts]
-			self.cases[new_keys] = Statement.cast(stmts)
+			# XXX(aki): See note on `self.test` assignment
+			self.cases[new_keys] = Statement.cast(stmts, src_loc_at = 1 + src_loc_at)
 			if orig_keys in case_src_locs:
 				self.case_src_locs[new_keys] = case_src_locs[orig_keys]
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -18,6 +18,7 @@ from typing            import (
 )
 
 from ..diagnostics     import ToriiSyntaxError, ToriiSyntaxWarning, UnusedProperty
+from ..diagnostics     import IndexError as ToriiIndexError
 from .._typing         import SrcLoc, SwitchCaseT
 from ..util            import _check_name, flatten, tracer, union
 from ..util.decorators import final
@@ -352,7 +353,7 @@ def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
 	n = len(value)
 	if isinstance(key, int):
 		if key not in range(-n, n):
-			raise ToriiSyntaxError(
+			raise ToriiIndexError(
 				f'Index {key} is out of bounds for a {n}-bit value',
 				tracer.get_src_loc(src_loc_at = 1)
 			)

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -511,7 +511,7 @@ class Value(metaclass = ABCMeta):
 			# an unsigned value.
 			raise ToriiSyntaxError(
 				'Shift amount must be unsigned',
-				tracer.get_src_loc(src_loc_at = src_loc_at)
+				tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 			)
 
 	@_overridable_by_swapping('__rlshift__')

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -3197,7 +3197,13 @@ class SignalKey:
 		elif type(signal) is ResetSignal:
 			self._intern = (2, signal.domain)
 		else:
-			raise TypeError(f'Object {signal!r} is not an Torii signal')
+			raise ToriiSyntaxError(
+				f'Objects of type {type(signal).__name__} can not be used as a key in Torii signal collections',
+				tracer.get_src_loc(),
+				notes = [
+					'Only Torii signal types can be used, they are: Signal, ClockSignal, and ResetSignal'
+				]
+			)
 
 	def __hash__(self) -> int:
 		return hash(self._intern)
@@ -3209,7 +3215,11 @@ class SignalKey:
 
 	def __lt__(self, other: object) -> bool:
 		if type(other) is not SignalKey:
-			raise TypeError(f'Object {other!r} cannot be compared to a SignalKey')
+			raise ToriiSyntaxError(
+				f'Objects of type {type(other).__name__} cannot be compared to a SignalKey',
+				tracer.get_src_loc()
+			)
+
 		# NOTE(aki): This comparison works fine, but typing is having a hard time seeing through it
 		return self._intern < other._intern # type: ignore
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -313,7 +313,10 @@ class ShapeLike(metaclass = _ShapeLikeMeta):
 	'''
 
 	def __new__(cls, *args, **kwargs):
-		raise TypeError('ShapeLike is an abstract class and cannot be constructed')
+		raise ToriiError(
+			message = 'The class \'ShapeLike\' is an abstract class and cannot be directly constructed',
+			src_loc = tracer.get_src_loc()
+		)
 
 def unsigned(width: int, *, src_loc_at: int = 0) -> Shape:
 	''' Shorthand for ``Shape(width, signed = False)``. '''

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -3246,7 +3246,10 @@ class SignalSet(_MappedKeySet[SignalLikeT | None, SignalKey]):
 
 	def _map_key(self, key: SignalLikeT | None) -> SignalKey:
 		if key is None:
-			raise TypeError('Key to SignalSet must not be None')
+			raise ToriiSyntaxError(
+				'SignalSet key must not be None',
+				tracer.get_src_loc(src_loc_at = 1)
+			)
 
 		return SignalKey(key)
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -206,7 +206,7 @@ class Shape:
 			else:
 				width  = max(width, member_shape.width)
 
-		return Shape(width, signed)
+		return Shape(width, signed, src_loc_at = 1 + src_loc_at)
 
 	@staticmethod
 	def cast(obj: object, *, src_loc_at: int = 0) -> Shape:

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -3231,7 +3231,10 @@ class SignalDict(_MappedKeyDict[SignalLikeT, Val, SignalKey]):
 
 	def _map_key(self, key: SignalLikeT | None) -> SignalKey:
 		if key is None:
-			raise TypeError('Key to SignalDict must not be None')
+			raise ToriiSyntaxError(
+				'SignalDict key must not be None',
+				tracer.get_src_loc(src_loc_at = 1)
+			)
 
 		return SignalKey(key)
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1615,15 +1615,32 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 
 		if name is not None:
 			if not isinstance(name, str):
-				raise TypeError(f'Name must be a string, not {name!r}')
+				raise ToriiSyntaxError(
+					f'Signal names must be a string, not {name!r}',
+					self.src_loc
+				)
+
 			if name == '' or not _check_name(name):
-				raise NameError('Signal name must not be empty or contain any control or whitespace characters')
+				err = ToriiSyntaxError(
+					'Signal names may not be empty or contain any control or whitespace characters',
+					self.src_loc,
+				)
+
+				if name == '':
+					err.add_note('An empty string was provided to the `name` parameter, was this intentional?')
+				else:
+					err.add_note(
+						'A character in the name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, Zs,'
+						' Zl, Zp'
+					)
+
+				raise err
 
 		self.name = name or tracer.get_var_name(depth = 2 + src_loc_at, default = '$signal')
 
 		orig_shape = shape
 		if shape is None:
-			shape = unsigned(1)
+			shape = unsigned(1, src_loc_at = 1 + src_loc_at)
 		else:
 			shape = Shape.cast(shape, src_loc_at = 1 + src_loc_at)
 		self.width  = shape.width
@@ -1632,53 +1649,84 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 		if isinstance(orig_shape, ShapeCastable):
 			try:
 				reset_val = Const.cast(orig_shape.const(reset))
-			except Exception:
-				raise TypeError(
-					f'Reset value must be a constant initializer of {orig_shape!r}'
-				)
+			except Exception as e:
+				raise ToriiSyntaxError(
+					f'The reset value for the signal \'{self.name}\' must be a constant initializer of shape'
+					f' {orig_shape!r}',
+					self.src_loc
+				) from e
 
 			if reset_val.shape() != Shape.cast(orig_shape):
-				raise ValueError(
-					f'Constant returned by {orig_shape!r}.const() must have the shape that it casts '
-					f'to, {Shape.cast(orig_shape)!r}, and not {reset_val.shape()!r}'
+				raise ToriiSyntaxError(
+					f'The reset value for the signal \'{self.name}\' has different const and non-const shapes',
+					self.src_loc,
+					notes = [
+						f'The constant version of {orig_shape!r} turns into {reset_val.shape()!r}, not the'
+						f' expected {Shape.cast(orig_shape)!r}'
+					]
 				)
 		else:
 			try:
 				reset_val = Const.cast(reset or 0)
-			except ToriiSyntaxError:
-				raise TypeError(
-					f'Reset value must be a constant-castable expression, not {reset!r}'
-				)
+			except ToriiSyntaxError as e:
+				raise ToriiSyntaxError(
+					f'The reset value for the signal \'{self.name}\' must be a constant-castable expression, not '
+					f'{reset!r}',
+					self.src_loc
+				) from e
 
 		# Avoid false positives for all-zeroes and all-ones
 		if reset not in (None, 0, -1):
-			if reset_val.shape().signed and not self.signed:
+			reset_shape = reset_val.shape(src_loc_at = 1 + src_loc_at)
+			if reset_shape.signed and not self.signed:
 				warnings.warn(
-					message = f'Reset value {reset!r} is signed, but the signal shape is {shape!r}',
+					message = f'The reset value for \'{self.name}\' is signed while the signal itself is unsigned',
 					category = ToriiSyntaxWarning,
-					stacklevel = 2
+					stacklevel = 2 + src_loc_at,
 				)
 			elif (
-				reset_val.shape().width > self.width or
-				reset_val.shape().width == self.width and
-				self.signed and not reset_val.shape().signed
+				reset_shape.width > self.width or
+				reset_shape.width == self.width and
+				self.signed and not reset_shape.signed
 			):
-				warnings.warn(
-					message = f'Reset value {reset!r} will be truncated to the signal shape {shape!r}',
-					category = ToriiSyntaxWarning,
-					stacklevel = 2
+				warning = ToriiSyntaxWarning(
+					f'The reset value for the signal \'{self.name}\' will be truncated to match its width'
 				)
+
+				if reset_shape.width > self.width:
+					warning.add_note(
+						f'The signal \'{self.name}\' is {self.width} bit(s) wide where as the reset value is'
+						f' {reset_shape.width} bit(s) wide, causing a truncation of'
+						f' {reset_shape.width - self.width} bit(s)'
+					)
+
+				if self.signed and not reset_shape.signed:
+					warning.add_note(
+						f'The signal \'{self.name}\' is signed where as the reset value for it is unsigned'
+					)
+
+				warnings.warn(warning, stacklevel = 2 + src_loc_at)
+
 		self.reset = reset_val.value
 		self.reset_less = bool(reset_less)
 
 		if isinstance(orig_shape, range) and reset is not None and reset not in orig_shape:
 			if reset == orig_shape.stop:
-				raise SyntaxError(
-					f'Reset value {reset!r} equals the non-inclusive end of the signal '
-					f'shape {orig_shape!r}; this is likely an off-by-one error',
+				raise ToriiSyntaxError(
+					f'The reset value {reset} for the signal \'{self.name}\' is equal to the non-inclusive'
+					' end of the signal width; this is very likely an off-by-one error',
+					self.src_loc,
+					notes = [
+						f'The signal \'{self.name}\' is {orig_shape.stop - 1} bit(s) wide:'
+						f' [{orig_shape.start}:{orig_shape.stop - 1}]'
+					]
 				)
 			else:
-				raise SyntaxError(f'Reset value {reset!r} is not within the signal shape {orig_shape!r}')
+				raise ToriiSyntaxError(
+					f'The reset value {reset} falls outside the valid range for the signal \'{self.name}\''
+					f' [{orig_shape.start}:{orig_shape.stop - 1}]',
+					self.src_loc
+				)
 
 		self.attrs = OrderedDict(() if attrs is None else attrs)
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2315,7 +2315,7 @@ class Sample(Value):
 
 	def __init__(self, expr: ValueCastT, clocks: int, domain: str | None, *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = src_loc_at)
-		self.value  = Value.cast(expr)
+		self.value  = Value.cast(expr, src_loc_at = 1 + src_loc_at)
 		self.clocks = int(clocks)
 		self.domain = domain
 
@@ -2359,7 +2359,7 @@ class Sample(Value):
 	def __repr__(self) -> str:
 		return f'(sample {self.value!r} @ {"<default>" if self.domain is None else self.domain}[{self.clocks}])'
 
-def Past(expr: ValueCastT, clocks: int = 1, domain: str | None = None) -> Value:
+def Past(expr: ValueCastT, clocks: int = 1, domain: str | None = None, *, src_loc_at: int = 0) -> Value:
 	'''
 	Get a value from the past.
 
@@ -2400,10 +2400,10 @@ def Past(expr: ValueCastT, clocks: int = 1, domain: str | None = None) -> Value:
 		The sample value.
 	'''
 
-	return Sample(expr, clocks, domain, src_loc_at = 1)
+	return Sample(expr, clocks, domain, src_loc_at = 1 + src_loc_at)
 
 # NOTE(aki): For Stable, Rose, Fell, and Edge, mypy can't see through the operators
-def Stable(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operator:
+def Stable(expr: ValueCastT, clocks: int = 0, domain: str | None = None, *, src_loc_at: int = 0) -> Operator:
 	'''
 	Check if a Signal is stable over the given ``clocks + 1`` cycles in the past.
 
@@ -2434,12 +2434,15 @@ def Stable(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Oper
 
 	op = Sample(expr, clocks + 1, domain, src_loc_at = 1) == Sample(expr, clocks, domain, src_loc_at = 1)
 
+	# Fixup the source locality information for op
+	op.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 	if TYPE_CHECKING:
 		assert isinstance(op, Operator)
 
 	return op
 
-def Rose(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operator:
+def Rose(expr: ValueCastT, clocks: int = 0, domain: str | None = None, *, src_loc_at: int = 0) -> Operator:
 	'''
 	Check if the given Signal rose in the past ``clocks + 1`` clock cycles.
 
@@ -2470,12 +2473,15 @@ def Rose(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 
 	op = ~Sample(expr, clocks + 1, domain, src_loc_at = 1) & Sample(expr, clocks, domain, src_loc_at = 1)
 
+	# Fixup the source locality information for op
+	op.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 	if TYPE_CHECKING:
 		assert isinstance(op, Operator)
 
 	return op
 
-def Fell(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operator:
+def Fell(expr: ValueCastT, clocks: int = 0, domain: str | None = None, *, src_loc_at: int = 0) -> Operator:
 	'''
 	Check if the given Signal fell in the past ``clocks + 1`` clock cycles.
 
@@ -2506,12 +2512,15 @@ def Fell(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 
 	op = Sample(expr, clocks + 1, domain, src_loc_at = 1) & ~Sample(expr, clocks, domain, src_loc_at = 1)
 
+	# Fixup the source locality information for op
+	op.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 	if TYPE_CHECKING:
 		assert isinstance(op, Operator)
 
 	return op
 
-def Edge(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operator:
+def Edge(expr: ValueCastT, clocks: int = 0, domain: str | None = None, *, src_loc_at: int = 0) -> Operator:
 	'''
 	Check if the given Signal rose or fell in the past ``clocks + 1`` clock cycles.
 
@@ -2541,6 +2550,9 @@ def Edge(expr: ValueCastT, clocks: int = 0, domain: str | None = None) -> Operat
 	'''
 
 	op = Sample(expr, clocks + 1, domain, src_loc_at = 1) != Sample(expr, clocks, domain, src_loc_at = 1)
+
+	# Fixup the source locality information for op
+	op.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
 
 	if TYPE_CHECKING:
 		assert isinstance(op, Operator)

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -187,7 +187,7 @@ class Shape:
 		for member in obj: # type: ignore
 			try:
 				member_shape = Const.cast(member.value).shape() # type: ignore
-			except TypeError:
+			except ToriiSyntaxError:
 				raise ToriiSyntaxError(
 					'Only enumerations whose members have constant-castable '
 					'values can be used in Torii code',
@@ -400,6 +400,7 @@ class Value(metaclass = ABCMeta):
 		:py:class:`ValueCastable` objects are recursively cast to an Torii value.
 
 		'''
+
 		while True:
 			if isinstance(obj, Value):
 				return obj
@@ -407,23 +408,46 @@ class Value(metaclass = ABCMeta):
 				# NOTE(aki): See TODO on `ValueCastable.__init_subclass__`
 				new_obj = obj.as_value() # type: ignore
 			elif isinstance(obj, Enum):
-				return Const(obj.value, Shape.cast(type(obj), src_loc_at = 1 + src_loc_at))
+				return Const(
+					obj.value, Shape.cast(type(obj), src_loc_at = 1 + src_loc_at),
+					src_loc_at = 1 + src_loc_at
+				)
 			elif isinstance(obj, int):
-				return Const(obj)
+				return Const(obj, src_loc_at = 1 + src_loc_at)
 			else:
-				raise TypeError(f'Object {obj!r} cannot be converted to a Torii value')
+				raise ToriiSyntaxError(
+					f'Object {obj!r} cannot be converted to a Torii value',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
+
 			if new_obj is obj:
-				raise RecursionError(f'Value-castable object {obj!r} casts to itself')
+				raise ToriiSyntaxError(
+					f'Value-castable object {obj!r} casts to itself',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
 			obj = new_obj
 
 	def __init__(self, *, src_loc_at: int = 0) -> None:
 		super().__init__()
+		# NOTE:
+		# This may look incorrect, but `Value`'s are very rarely directly constructed,
+		# but rather the `__init__` is called from subclasses, therefore we offset the
+		# callstack count by one to account for this
 		self.src_loc = tracer.get_src_loc(1 + src_loc_at)
 
 	def __bool__(self) -> None:
-		raise TypeError('Attempted to convert Torii value to Python boolean')
+		raise ToriiSyntaxError(
+			'Attempted to convert Torii value to Python boolean',
+			tracer.get_src_loc()
+		)
 
 	def __pos__(self) -> Value:
+		warnings.warn(
+			'The unary + operator has no effect on Torii values',
+			ToriiSyntaxWarning,
+			stacklevel = 2
+		)
+
 		return self
 
 	def __invert__(self) -> Operator:
@@ -467,17 +491,33 @@ class Value(metaclass = ABCMeta):
 	def __rfloordiv__(self, other: ValueCastT) -> Operator:
 		return Operator('//', (other, self))
 
-	def __check_shamt(self) -> None:
+	@_overridable_by_swapping('__rtruediv__')
+	def __truediv__(self, other: ValueCastT):
+		raise ToriiSyntaxError(
+			'Only flooring/integer division (\'//\') is supported on Torii values',
+			tracer.get_src_loc(src_loc_at = 1)
+		)
+
+	def __rtruediv__(self, other: ValueCastT):
+		raise ToriiSyntaxError(
+			'Only flooring/integer division (\'//\') is supported on Torii values',
+			tracer.get_src_loc()
+		)
+
+	def __check_shamt(self, src_loc_at: int = 0) -> None:
 		if self.shape().signed:
 			# Neither Python nor HDLs implement shifts by negative values; prohibit any shifts
 			# by a signed value to make sure the shift amount can always be interpreted as
 			# an unsigned value.
-			raise TypeError('Shift amount must be unsigned')
+			raise ToriiSyntaxError(
+				'Shift amount must be unsigned',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
 	@_overridable_by_swapping('__rlshift__')
 	def __lshift__(self, other: ValueCastT) -> Operator:
-		other = Value.cast(other)
-		other.__check_shamt()
+		other = Value.cast(other, src_loc_at = 1)
+		other.__check_shamt(src_loc_at = 1)
 		return Operator('<<', (self, other), src_loc_at = 1)
 
 	def __rlshift__(self, other: ValueCastT) -> Operator:
@@ -486,8 +526,8 @@ class Value(metaclass = ABCMeta):
 
 	@_overridable_by_swapping('__rrshift__')
 	def __rshift__(self, other: ValueCastT) -> Operator:
-		other = Value.cast(other)
-		other.__check_shamt()
+		other = Value.cast(other, src_loc_at = 1)
+		other.__check_shamt(src_loc_at = 1)
 		return Operator('>>', (self, other), src_loc_at = 1)
 
 	def __rrshift__(self, other: ValueCastT) -> Operator:
@@ -541,7 +581,8 @@ class Value(metaclass = ABCMeta):
 
 	def __abs__(self) -> Value:
 		if self.shape().signed:
-			return Mux(self >= 0, self, -self)[:len(self)]
+			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
+			return _index_valuelike(Mux(self >= 0, self, -self), slice(len(self)))
 		else:
 			return self
 
@@ -552,9 +593,12 @@ class Value(metaclass = ABCMeta):
 		return _index_valuelike(self, key)
 
 	def __contains__(self, _):
-		raise TypeError('The python `in` operator is not supported on Torii values')
+		raise ToriiSyntaxError(
+			'The python `in` operator is not supported on Torii values',
+			tracer.get_src_loc()
+		)
 
-	def as_unsigned(self)  -> Operator:
+	def as_unsigned(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Conversion to unsigned.
 
@@ -564,9 +608,9 @@ class Value(metaclass = ABCMeta):
 			This ``Value`` reinterpreted as a unsigned integer.
 		'''
 
-		return Operator('u', (self,))
+		return Operator('u', (self,), src_loc_at = src_loc_at)
 
-	def as_signed(self)  -> Operator:
+	def as_signed(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Conversion to signed.
 
@@ -577,10 +621,17 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if len(self) == 0:
-			raise ValueError('Cannot create a 0-width signed value')
-		return Operator('s', (self,))
+			raise ToriiSyntaxError(
+				'Cannot create a 0-width signed value',
+				tracer.get_src_loc(src_loc_at = src_loc_at),
+				notes = [
+					'Torii values are stored in 2\'s-complement, therefore at least one bit must be present'
+					' to indicate signedness'
+				]
+			)
+		return Operator('s', (self,), src_loc_at = src_loc_at)
 
-	def bool(self)  -> Operator:
+	def bool(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Conversion to boolean.
 
@@ -590,9 +641,9 @@ class Value(metaclass = ABCMeta):
 			``1`` if any bits are set, ``0`` otherwise.
 		'''
 
-		return Operator('b', (self,))
+		return Operator('b', (self,), src_loc_at = src_loc_at)
 
-	def any(self)  -> Operator:
+	def any(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Check if any bits are ``1``.
 
@@ -602,9 +653,9 @@ class Value(metaclass = ABCMeta):
 			``1`` if any bits are set, ``0`` otherwise.
 		'''
 
-		return Operator('r|', (self,))
+		return Operator('r|', (self,), src_loc_at = src_loc_at)
 
-	def all(self)  -> Operator:
+	def all(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Check if all bits are ``1``.
 
@@ -614,9 +665,9 @@ class Value(metaclass = ABCMeta):
 			``1`` if all bits are set, ``0`` otherwise.
 		'''
 
-		return Operator('r&', (self,))
+		return Operator('r&', (self,), src_loc_at = src_loc_at)
 
-	def xor(self)  -> Operator:
+	def xor(self, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Compute pairwise exclusive-or of every bit.
 
@@ -626,9 +677,9 @@ class Value(metaclass = ABCMeta):
 			``1`` if an odd number of bits are set, ``0`` if an even number of bits are set.
 		'''
 
-		return Operator('r^', (self,))
+		return Operator('r^', (self,), src_loc_at = src_loc_at)
 
-	def implies(premise, conclusion: ValueCastT)  -> Operator:
+	def implies(premise, conclusion: ValueCastT, *, src_loc_at: int = 0)  -> Operator:
 		'''
 		Implication.
 
@@ -643,9 +694,12 @@ class Value(metaclass = ABCMeta):
 		if TYPE_CHECKING:
 			assert isinstance(op, Operator)
 
+		# Fixup the source locality information for op
+		op.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 		return op
 
-	def bit_select(self, offset: Value | int, width: int) -> Value:
+	def bit_select(self, offset: Value | int, width: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Part-select with bit granularity.
 
@@ -666,12 +720,13 @@ class Value(metaclass = ABCMeta):
 			Selected part of the ``Value``
 		'''
 
-		offset = Value.cast(offset)
+		offset = Value.cast(offset, src_loc_at = 1 + src_loc_at)
 		if type(offset) is Const and isinstance(width, int):
-			return self[offset.value:offset.value + width]
-		return Part(self, offset, width, stride = 1, src_loc_at = 1)
+			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
+			return _index_valuelike(self, slice(offset.value, offset.value + width))
+		return Part(self, offset, width, stride = 1, src_loc_at = 1 + src_loc_at)
 
-	def word_select(self, offset: Value | int, width: int) -> Value:
+	def word_select(self, offset: Value | int, width: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Part-select with word granularity.
 
@@ -692,12 +747,13 @@ class Value(metaclass = ABCMeta):
 			Selected part of the ``Value``
 		'''
 
-		offset = Value.cast(offset)
+		offset = Value.cast(offset, src_loc_at = 1 + src_loc_at)
 		if type(offset) is Const and isinstance(width, int):
-			return self[offset.value * width:(offset.value + 1) * width]
-		return Part(self, offset, width, stride = width, src_loc_at = 1)
+			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
+			return _index_valuelike(self, slice(offset.value * width, (offset.value + 1) * width))
+		return Part(self, offset, width, stride = width, src_loc_at = 1 + src_loc_at)
 
-	def matches(self, *patterns: int | str | EnumMeta) -> Value:
+	def matches(self, *patterns: int | str | EnumMeta, src_loc_at: int = 0) -> Value:
 		'''
 		Pattern matching.
 
@@ -719,14 +775,16 @@ class Value(metaclass = ABCMeta):
 		# This code should accept exactly the same patterns as `with m.Case(...):`.
 		for pattern in patterns:
 			if isinstance(pattern, str) and any(bit not in '01- \t' for bit in pattern):
-				raise SyntaxError(
+				raise ToriiSyntaxError(
 					f'Match pattern \'{pattern}\' must consist of 0, 1, and - (don\'t care) bits, and may '
-					'include whitespace'
+					'include whitespace',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
 				)
 
 			if (isinstance(pattern, str) and len(''.join(pattern.split())) != len(self)):
-				raise SyntaxError(
-					f'Match pattern \'{pattern}\' must have the same width as match value (which is {len(self)})'
+				raise ToriiSyntaxError(
+					f'Match pattern \'{pattern}\' must have the same width as match value (which is {len(self)})',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
 				)
 
 			if isinstance(pattern, str):
@@ -738,10 +796,11 @@ class Value(metaclass = ABCMeta):
 				try:
 					# NOTE(aki): mypy has issues with this re-assignment, but it's fine
 					new_pattern: Const = Const.cast(pattern)
-				except TypeError as error:
-					raise SyntaxError(
+				except ToriiSyntaxError as error:
+					raise ToriiSyntaxError(
 						'Match pattern must be a string or a const-castable expression, '
-						f'not {pattern!r}'
+						f'not {pattern!r}',
+						tracer.get_src_loc(src_loc_at = src_loc_at)
 					) from error
 
 				pattern_len = bits_for(new_pattern.value)
@@ -759,13 +818,16 @@ class Value(metaclass = ABCMeta):
 				'Value.matches() with an empty patterns clause will return `Const(0)` in a future release.',
 				ToriiSyntaxWarning, stacklevel = 2
 			)
-			return Const(1)
+			return Const(1, src_loc_at = 1 + src_loc_at)
 		elif len(matches) == 1:
-			return matches[0]
+			mtch = matches[0]
+			# Fixup source locality
+			mtch.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+			return mtch
 		else:
-			return Cat(*matches).any()
+			return Cat(*matches).any(src_loc_at = 1 + src_loc_at)
 
-	def shift_left(self, amount: int) -> Value:
+	def shift_left(self, amount: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Shift left by constant amount.
 
@@ -781,15 +843,20 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if not isinstance(amount, int):
-			raise TypeError(f'Shift amount must be an integer, not {amount!r}')
-		if amount < 0:
-			return self.shift_right(-amount)
-		if self.shape().signed:
-			return Cat(Const(0, amount), self).as_signed()
-		else:
-			return Cat(Const(0, amount), self) # unsigned
+			raise ToriiSyntaxError(
+				f'Shift amount must be an integer, not {amount!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
-	def shift_right(self, amount: int) -> Value:
+		if amount < 0:
+			return self.shift_right(-amount, src_loc_at = 1 + src_loc_at)
+
+		if self.shape().signed:
+			return Cat(Const(0, amount), self).as_signed(src_loc_at = 1 + src_loc_at)
+		else:
+			return Cat(Const(0, amount), self, src_loc_at = 1 + src_loc_at) # unsigned
+
+	def shift_right(self, amount: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Shift right by constant amount.
 
@@ -805,17 +872,23 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if not isinstance(amount, int):
-			raise TypeError(f'Shift amount must be an integer, not {amount!r}')
+			raise ToriiSyntaxError(
+				f'Shift amount must be an integer, not {amount!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if amount < 0:
-			return self.shift_left(-amount)
+			return self.shift_left(-amount, src_loc_at = 1 + src_loc_at)
+
 		if self.shape().signed:
 			if amount >= len(self):
 				amount = len(self) - 1
-			return self[amount:].as_signed()
+			return self[amount:].as_signed(src_loc_at = 1 + src_loc_at)
 		else:
-			return self[amount:] # unsigned
+			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
+			return _index_valuelike(self, slice(amount, None)) # unsigned
 
-	def rotate_left(self, amount: int) -> Value:
+	def rotate_left(self, amount: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Rotate left by constant amount.
 
@@ -831,12 +904,17 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if not isinstance(amount, int):
-			raise TypeError(f'Rotate amount must be an integer, not {amount!r}')
+			raise ToriiSyntaxError(
+				f'Rotate amount must be an integer, not {amount!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if len(self) != 0:
 			amount %= len(self)
-		return Cat(self[-amount:], self[:-amount]) # meow :3
 
-	def rotate_right(self, amount: int) -> Value:
+		return Cat(self[-amount:], self[:-amount], src_loc_at = 1 + src_loc_at) # meow :3
+
+	def rotate_right(self, amount: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Rotate right by constant amount.
 
@@ -852,12 +930,17 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if not isinstance(amount, int):
-			raise TypeError(f'Rotate amount must be an integer, not {amount!r}')
+			raise ToriiSyntaxError(
+				f'Rotate amount must be an integer, not {amount!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if len(self) != 0:
 			amount %= len(self)
-		return Cat(self[amount:], self[:amount])
 
-	def replicate(self, count: int) -> Value:
+		return Cat(self[amount:], self[:amount], src_loc_at = 1 + src_loc_at)
+
+	def replicate(self, count: int, *, src_loc_at: int = 0) -> Value:
 		'''
 		Replication.
 
@@ -878,10 +961,14 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		if not isinstance(count, int) or count < 0:
-			raise TypeError(f'Replication count must be a non-negative integer, not {count!r}')
-		return Cat(*(self for _ in range(count)))
+			raise ToriiSyntaxError(
+				f'Replication count must be a non-zero positive integer, not {count!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
-	def eq(self, value: ValueCastT) -> Assign:
+		return Cat(*(self for _ in range(count)), src_loc_at = 1 + src_loc_at)
+
+	def eq(self, value: ValueCastT, *, src_loc_at: int = 0) -> Assign:
 		'''
 		Assignment.
 
@@ -896,9 +983,9 @@ class Value(metaclass = ABCMeta):
 			Assignment statement that can be used in combinatorial or synchronous context.
 		'''
 
-		return Assign(self, value, src_loc_at = 1)
+		return Assign(self, value, src_loc_at = 1 + src_loc_at)
 
-	def inc(self, value: ValueCastT = 1) -> Assign:
+	def inc(self, value: ValueCastT = 1, *, src_loc_at: int = 0) -> Assign:
 		'''
 		Increment value.
 
@@ -915,9 +1002,9 @@ class Value(metaclass = ABCMeta):
 			Assignment statement that can be used in combinatorial or synchronous context.
 		'''
 
-		return Assign(self, self + value, src_loc_at = 1)
+		return Assign(self, self + value, src_loc_at = 1 + src_loc_at)
 
-	def dec(self, value: ValueCastT = 1) -> Assign:
+	def dec(self, value: ValueCastT = 1, *, src_loc_at: int = 0) -> Assign:
 		'''
 		Decrement value.
 
@@ -934,7 +1021,7 @@ class Value(metaclass = ABCMeta):
 			Assignment statement that can be used in combinatorial or synchronous context.
 		'''
 
-		return Assign(self, self - value, src_loc_at = 1)
+		return Assign(self, self - value, src_loc_at = 1 + src_loc_at)
 
 	@abstractmethod
 	def shape(self) -> Shape:
@@ -963,7 +1050,10 @@ class Value(metaclass = ABCMeta):
 		.. todo:: Document Me
 		'''
 
-		raise TypeError(f'Value {self!r} cannot be used in assignments')
+		raise ToriiSyntaxError(
+			f'Value {self!r} cannot be used in assignments',
+			tracer.get_src_loc()
+		)
 
 	@abstractmethod
 	def _rhs_signals(self) -> SignalSet | ValueSet:
@@ -1033,7 +1123,7 @@ class Const(Value, metaclass = _ConstMeta):
 		Otherwise, :py:exc:`TypeError` is raised.
 		'''
 
-		obj = Value.cast(obj)
+		obj = Value.cast(obj, src_loc_at = 1 + src_loc_at)
 		if type(obj) is Const:
 			return obj
 		elif type(obj) is Cat:

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1578,13 +1578,34 @@ class ResetSignal(Value):
 	def __init__(self, domain: str = 'sync', allow_reset_less: bool = False, *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = src_loc_at)
 		if not isinstance(domain, str):
-			raise TypeError(f'Clock domain name must be a string, not {domain!r}')
+			raise ToriiSyntaxError(
+				f'The domain name for this reset signal must be a string, not {domain!r}',
+				self.src_loc,
+			)
 
 		if domain == '' or not _check_name(domain):
-			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+			err = ToriiSyntaxError(
+				'The domain name for this reset signal must not be empty or contain any control or whitespace '
+				'characters',
+				self.src_loc,
+			)
+
+			if domain == '':
+				err.add_note('An empty string was provided to the `domain` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the domain name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, '
+					'Zs, Zl, Zp'
+				)
+
+			raise err
 
 		if domain == 'comb':
-			raise ValueError(f'Domain \'{domain}\' does not have a reset')
+			raise ToriiSyntaxError(
+				'The combinatorial logic domain \'comb\' does not have a reset',
+				self.src_loc,
+			)
+
 		self.domain = domain
 		self.allow_reset_less = allow_reset_less
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2600,7 +2600,7 @@ class Statement:
 	'''
 
 	def __init__(self, *, src_loc_at: int = 0) -> None:
-		self.src_loc = tracer.get_src_loc(1 + src_loc_at)
+		self.src_loc = tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 
 	@staticmethod
 	def cast(obj: Iterable | Statement, src_loc_at: int = 0):
@@ -2610,9 +2610,9 @@ class Statement:
 
 		# Make sure we guard against infinite recursion if we hit a string,
 		if isinstance(obj, Iterable) and not isinstance(obj, str):
-			return _StatementList(
-				list(chain.from_iterable(map(lambda stmt: Statement.cast(stmt, src_loc_at + 2), obj)))
-			)
+			return _StatementList(list(chain.from_iterable(
+					map(lambda stmt: Statement.cast(stmt, src_loc_at = 2 + src_loc_at), obj)
+			)))
 		else:
 			if isinstance(obj, Statement):
 				return _StatementList([obj])

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1083,7 +1083,7 @@ class _ConstMeta(ABCMeta):
 		):
 		if isinstance(shape, ShapeCastable):
 			return shape.const(value)
-		return super().__call__(value, shape, **kwargs, src_loc_at = src_loc_at + 1)
+		return super().__call__(value, shape, **kwargs, src_loc_at = 1 + src_loc_at)
 
 @final
 class Const(Value, metaclass = _ConstMeta):
@@ -1943,7 +1943,7 @@ class AnyValue(Value, DUID):
 		super().__init__(src_loc_at = src_loc_at)
 
 		self.kind   = self.Kind(kind)
-		self._shape = Shape.cast(shape, src_loc_at = src_loc_at + 1)
+		self._shape = Shape.cast(shape, src_loc_at = 1 + src_loc_at)
 		self.width  = self._shape.width
 		self.signed = self._shape.signed
 
@@ -1961,14 +1961,14 @@ def AnyConst(shape, *, src_loc_at: int = 0) -> AnyValue:
 	.. todo:: Document Me
 	'''
 
-	return AnyValue('anyconst', shape, src_loc_at = src_loc_at + 1)
+	return AnyValue('anyconst', shape, src_loc_at = 1 + src_loc_at)
 
 def AnySeq(shape, *, src_loc_at: int = 0) -> AnyValue:
 	'''
 	.. todo:: Document Me
 	'''
 
-	return AnyValue('anyseq', shape, src_loc_at = src_loc_at + 1)
+	return AnyValue('anyseq', shape, src_loc_at = 1 + src_loc_at)
 
 class Array(MutableSequence[Value]):
 	'''
@@ -2708,21 +2708,21 @@ def Assert(test: ValueCastT, *, name: str | None = None, src_loc_at: int = 0) ->
 	.. todo:: Document Me
 	'''
 
-	return Property('assert', test, name = name, src_loc_at = src_loc_at + 1)
+	return Property('assert', test, name = name, src_loc_at = 1 + src_loc_at)
 
 def Assume(test: ValueCastT, *, name: str | None = None, src_loc_at: int = 0) -> Property:
 	'''
 	.. todo:: Document Me
 	'''
 
-	return Property('assume', test, name = name, src_loc_at = src_loc_at + 1)
+	return Property('assume', test, name = name, src_loc_at = 1 + src_loc_at)
 
 def Cover(test: ValueCastT, *, name: str | None = None, src_loc_at: int = 0) -> Property:
 	'''
 	.. todo:: Document Me
 	'''
 
-	return Property('cover', test, name = name, src_loc_at = src_loc_at + 1)
+	return Property('cover', test, name = name, src_loc_at = 1 + src_loc_at)
 
 # @final
 class Switch(Statement):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1207,69 +1207,93 @@ class Operator(Value):
 	def __init__(self, operator: OperatorsT, operands: Sequence[ValueCastT], *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = 1 + src_loc_at)
 		self.operator = operator
-		self.operands = [ Value.cast(op) for op in operands ]
+		self.operands = [ Value.cast(op, src_loc_at = 1 + src_loc_at) for op in operands ]
 
 	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		def _bitwise_binary_shape(a_shape: Shape, b_shape: Shape) -> Shape:
 			if not a_shape.signed and not b_shape.signed:
 				# both operands unsigned
-				return unsigned(max(a_shape.width, b_shape.width))
+				return unsigned(max(a_shape.width, b_shape.width), src_loc_at = 2 + src_loc_at)
 			elif a_shape.signed and b_shape.signed:
 				# both operands signed
-				return signed(max(a_shape.width, b_shape.width))
+				return signed(max(a_shape.width, b_shape.width), src_loc_at = 2 + src_loc_at)
 			elif not a_shape.signed and b_shape.signed:
 				# first operand unsigned (add sign bit), second operand signed
-				return signed(max(a_shape.width + 1, b_shape.width))
+				return signed(max(a_shape.width + 1, b_shape.width), src_loc_at = 2 + src_loc_at)
 			else:
 				# first signed, second operand unsigned (add sign bit)
-				return signed(max(a_shape.width, b_shape.width + 1))
+				return signed(max(a_shape.width, b_shape.width + 1), src_loc_at = 2 + src_loc_at)
 
 		op_shapes = list(map(lambda x: x.shape(), self.operands))
-		if len(op_shapes) == 1:
+		op_count = len(op_shapes)
+
+		if op_count == 1:
 			a_shape, = op_shapes
 			if self.operator in ('+', '~'):
-				return Shape(a_shape.width, a_shape.signed)
+				return Shape(a_shape.width, a_shape.signed, src_loc_at = 1 + src_loc_at)
 			if self.operator == '-':
-				return Shape(a_shape.width + 1, True)
+				return Shape(a_shape.width + 1, True, src_loc_at = 1 + src_loc_at)
 			if self.operator in ('b', 'r|', 'r&', 'r^'):
-				return Shape(1, False)
+				return Shape(1, False, src_loc_at = 1 + src_loc_at)
 			if self.operator == 'u':
-				return Shape(a_shape.width, False)
+				return Shape(a_shape.width, False, src_loc_at = 1 + src_loc_at)
 			if self.operator == 's':
-				return Shape(a_shape.width, True)
-		elif len(op_shapes) == 2:
+				return Shape(a_shape.width, True, src_loc_at = 1 + src_loc_at)
+		elif op_count == 2:
 			a_shape, b_shape = op_shapes
 			if self.operator == '+':
 				o_shape = _bitwise_binary_shape(*op_shapes)
-				return Shape(o_shape.width + 1, o_shape.signed)
+				return Shape(o_shape.width + 1, o_shape.signed, src_loc_at = 1 + src_loc_at)
 			if self.operator == '-':
 				o_shape = _bitwise_binary_shape(*op_shapes)
-				return Shape(o_shape.width + 1, True)
+				return Shape(o_shape.width + 1, True, src_loc_at = 1 + src_loc_at)
 			if self.operator == '*':
-				return Shape(a_shape.width + b_shape.width, a_shape.signed or b_shape.signed)
+				return Shape(
+					a_shape.width + b_shape.width,
+					a_shape.signed or b_shape.signed,
+					src_loc_at = 1 + src_loc_at
+				)
 			if self.operator == '//':
-				return Shape(a_shape.width + b_shape.signed, a_shape.signed or b_shape.signed)
+				return Shape(
+					a_shape.width + b_shape.signed,
+					a_shape.signed or b_shape.signed,
+					src_loc_at = 1 + src_loc_at
+				)
 			if self.operator == '%':
-				return Shape(b_shape.width, b_shape.signed)
+				return Shape(b_shape.width, b_shape.signed, src_loc_at = 1 + src_loc_at)
 			if self.operator in ('<', '<=', '==', '!=', '>', '>='):
-				return Shape(1, False)
+				return Shape(1, False, src_loc_at = 1 + src_loc_at)
 			if self.operator in ('&', '^', '|'):
 				return _bitwise_binary_shape(*op_shapes)
 			if self.operator == '<<':
 				if b_shape.signed:
-					raise TypeError('Operator << operand must be unsigned!')
+					raise ToriiSyntaxError(
+						'The shift amount operand for the << operator must be unsigned',
+						tracer.get_src_loc(src_loc_at = src_loc_at)
+					)
 
-				return Shape(a_shape.width + 2 ** b_shape.width - 1, a_shape.signed)
+				return Shape(
+					a_shape.width + 2 ** b_shape.width - 1,
+					a_shape.signed,
+					src_loc_at = 1 + src_loc_at
+				)
 			if self.operator == '>>':
 				if b_shape.signed:
-					raise TypeError('Operator >> operand must be unsigned!')
+					raise ToriiSyntaxError(
+						'The shift amount operand for the >> operator must be unsigned',
+						tracer.get_src_loc(src_loc_at = src_loc_at)
+					)
 
-				return Shape(a_shape.width, a_shape.signed)
-		elif len(op_shapes) == 3:
+				return Shape(a_shape.width, a_shape.signed, src_loc_at = 1 + src_loc_at)
+		elif op_count == 3:
 			if self.operator == 'm':
 				s_shape, a_shape, b_shape = op_shapes
 				return _bitwise_binary_shape(a_shape, b_shape)
-		raise NotImplementedError(f'Operator {self.operator}/{len(op_shapes)} not implemented') # :nocov:
+
+		raise ToriiSyntaxError(
+			f'The operator \'{self.operator}\' with {op_count} operands does not exist',
+			tracer.get_src_loc(src_loc_at = src_loc_at)
+		)
 
 	def _lhs_signals(self) -> SignalSet | ValueSet:
 		if self.operator in ('u', 's'):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2630,8 +2630,8 @@ class Assign(Statement):
 
 	def __init__(self, lhs: ValueCastT, rhs: ValueCastT, *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = src_loc_at)
-		self.lhs = Value.cast(lhs)
-		self.rhs = Value.cast(rhs)
+		self.lhs = Value.cast(lhs, src_loc_at = 1 + src_loc_at)
+		self.rhs = Value.cast(rhs, src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> ValueSet | SignalSet:
 		return self.lhs._lhs_signals()

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2020,9 +2020,11 @@ class Array(MutableSequence[Value]):
 
 	'''
 
+	src_loc: SrcLoc
 	_proxy_at: SrcLoc | None
 
-	def __init__(self, iterable: Sequence[Value] = ()) -> None:
+	def __init__(self, iterable: Sequence[Value] = (), *, src_loc_at: int = 0) -> None:
+		self.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
 		self._inner    = list(iterable)
 		self._proxy_at = None
 		self._mutable  = True
@@ -2030,7 +2032,7 @@ class Array(MutableSequence[Value]):
 	# NOTE(aki): We overload this method, so we need to shush the type checker
 	def __getitem__(self, index: Value | ValueCastable | int) -> Value | ArrayProxy: # type: ignore
 		if isinstance(index, ValueCastable):
-			index = Value.cast(index)
+			index = Value.cast(index, src_loc_at = 1)
 
 		if isinstance(index, Value):
 			if self._mutable:
@@ -2043,14 +2045,21 @@ class Array(MutableSequence[Value]):
 	def __len__(self) -> int:
 		return len(self._inner)
 
-	def _check_mutability(self) -> None:
+	def _check_mutability(self, src_loc_at: int = 1) -> None:
 		if not self._mutable:
 			if self._proxy_at is None:
-				raise AttributeError('Array is not mutable, however no proxy location has been specified')
+				raise ToriiSyntaxError(
+					'Array is not mutable, however there is no known ArrayProxy',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
 
-			filename, lineno = self._proxy_at
-			raise ValueError(
-				f'Array can no longer be mutated after it was indexed with a value at {filename}:{lineno}'
+			raise ToriiSyntaxError(
+				'Array mutation is no longer safe in Python code after access by a Torii value',
+				tracer.get_src_loc(src_loc_at = src_loc_at),
+				additional_ctx = (
+					'The array was accessed with a Torii value here, creating an ArrayProxy:',
+					self._proxy_at
+				)
 			)
 
 	# NOTE(aki): The ignore on the type is because we're once again, overloading this method

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2265,7 +2265,10 @@ class ValueLike(metaclass = _ValueLikeMeta):
 	'''
 
 	def __new__(cls, *args, **kwargs):
-		raise TypeError('ValueLike is an abstract class and cannot be constructed')
+		raise ToriiError(
+			message = 'The class \'ValueLike\' is an abstract class and cannot be directly constructed',
+			src_loc = tracer.get_src_loc()
+		)
 
 @final
 class Sample(Value):

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2091,7 +2091,7 @@ class ArrayProxy(Value):
 	def __init__(self, elems, index: ValueCastT, *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = 1 + src_loc_at)
 		self.elems = elems
-		self.index = Value.cast(index)
+		self.index = Value.cast(index, src_loc_at = 1 + src_loc_at)
 
 	def __getattr__(self, attr) -> ArrayProxy:
 		return ArrayProxy([getattr(elem, attr) for elem in self.elems], self.index)
@@ -2099,13 +2099,13 @@ class ArrayProxy(Value):
 	def __getitem__(self, index) -> ArrayProxy:
 		return ArrayProxy([        elem[index] for elem in self.elems], self.index)
 
-	def _iter_as_values(self):
-		return (Value.cast(elem) for elem in self.elems)
+	def _iter_as_values(self, src_loc_at: int = 1):
+		return (Value.cast(elem, src_loc_at = src_loc_at) for elem in self.elems)
 
 	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		unsigned_width = signed_width = 0
 		has_unsigned = has_signed = False
-		for elem_shape in (elem.shape() for elem in self._iter_as_values()):
+		for elem_shape in (elem.shape() for elem in self._iter_as_values(src_loc_at = src_loc_at)):
 			if elem_shape.signed:
 				has_signed = True
 				signed_width = max(signed_width, elem_shape.width)
@@ -2119,11 +2119,11 @@ class ArrayProxy(Value):
 		if has_signed and has_unsigned and unsigned_width >= signed_width:
 			# Array contains both signed and unsigned values, and at least one of the unsigned
 			# values won't be zero-extended otherwise.
-			return signed(unsigned_width + 1)
+			return signed(unsigned_width + 1, src_loc_at = 1 + src_loc_at)
 		else:
 			# Array contains values of the same signedness, or else all of the unsigned values
 			# are zero-extended.
-			return Shape(max(unsigned_width, signed_width), has_signed)
+			return Shape(max(unsigned_width, signed_width), has_signed, src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> SignalSet | ValueSet:
 		signals = union((elem._lhs_signals() for elem in self._iter_as_values()), start = SignalSet())

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1536,13 +1536,34 @@ class ClockSignal(Value):
 	def __init__(self, domain: str = 'sync', *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = src_loc_at)
 		if not isinstance(domain, str):
-			raise TypeError(f'Clock domain name must be a string, not {domain!r}')
+			raise ToriiSyntaxError(
+				f'The domain name for this clock signal must be a string, not {domain!r}',
+				self.src_loc,
+			)
 
 		if domain == '' or not _check_name(domain):
-			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+			err = ToriiSyntaxError(
+				'The domain name for this clock signal must not be empty or contain any control or whitespace '
+				'characters',
+				self.src_loc,
+			)
+
+			if domain == '':
+				err.add_note('An empty string was provided to the `domain` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the domain name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, '
+					'Zs, Zl, Zp'
+				)
+
+			raise err
 
 		if domain == 'comb':
-			raise ValueError(f'Domain \'{domain}\' does not have a clock')
+			raise ToriiSyntaxError(
+				'The combinatorial logic domain \'comb\' does not have a clock',
+				self.src_loc,
+			)
+
 		self.domain = domain
 
 	def shape(self) -> Shape:

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -772,26 +772,31 @@ class Value(metaclass = ABCMeta):
 		'''
 
 		matches: list[Value] = []
+		src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 		# This code should accept exactly the same patterns as `with m.Case(...):`.
 		for pattern in patterns:
 			if isinstance(pattern, str) and any(bit not in '01- \t' for bit in pattern):
 				raise ToriiSyntaxError(
 					f'Match pattern \'{pattern}\' must consist of 0, 1, and - (don\'t care) bits, and may '
 					'include whitespace',
-					tracer.get_src_loc(src_loc_at = src_loc_at)
+					src_loc
 				)
 
 			if (isinstance(pattern, str) and len(''.join(pattern.split())) != len(self)):
 				raise ToriiSyntaxError(
 					f'Match pattern \'{pattern}\' must have the same width as match value (which is {len(self)})',
-					tracer.get_src_loc(src_loc_at = src_loc_at)
+					src_loc
 				)
 
 			if isinstance(pattern, str):
 				pattern = ''.join(pattern.split()) # remove whitespace
 				mask    = int(pattern.replace('0', '1').replace('-', '0'), 2)
 				pattern = int(pattern.replace('-', '0'), 2)
-				matches.append((self & mask) == pattern)
+				match_op = (self & mask) == pattern
+				# Fix up the source locality from the intermediate expression
+				match_op.src_loc = src_loc
+				matches.append(match_op)
 			else:
 				try:
 					# NOTE(aki): mypy has issues with this re-assignment, but it's fine
@@ -800,7 +805,7 @@ class Value(metaclass = ABCMeta):
 					raise ToriiSyntaxError(
 						'Match pattern must be a string or a const-castable expression, '
 						f'not {pattern!r}',
-						tracer.get_src_loc(src_loc_at = src_loc_at)
+						src_loc
 					) from error
 
 				pattern_len = bits_for(new_pattern.value)
@@ -820,10 +825,7 @@ class Value(metaclass = ABCMeta):
 			)
 			return Const(1, src_loc_at = 1 + src_loc_at)
 		elif len(matches) == 1:
-			mtch = matches[0]
-			# Fixup source locality
-			mtch.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
-			return mtch
+			return matches[0]
 		else:
 			return Cat(*matches).any(src_loc_at = 1 + src_loc_at)
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1061,6 +1061,8 @@ class Const(Value, metaclass = _ConstMeta):
 		self, value: int, shape: Shape | int | range | type | ShapeCastable | None = None, *,
 		src_loc_at: int = 0
 	) -> None:
+		self.src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
 		# We deliberately do not call Value.__init__ here.
 		self.value = int(operator.index(value))
 		if shape is None:

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1337,22 +1337,78 @@ class Slice(Value):
 		self, value: ValueCastT, start: int, stop: int, *, src_loc_at: int = 0
 	) -> None:
 		if not isinstance(start, int):
-			raise TypeError(f'Slice start must be an integer, not {start!r}')
-		if not isinstance(stop, int):
-			raise TypeError(f'Slice stop must be an integer, not {stop!r}')
+			raise ToriiSyntaxError(
+				f'The start index of a Slice must be an integer, not {start!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
-		value = Value.cast(value)
+		if not isinstance(stop, int):
+			raise ToriiSyntaxError(
+				f'The stop index of a Slice must be an integer, not {stop!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
+		value = Value.cast(value, src_loc_at = 1 + src_loc_at)
 		n = len(value)
 		if start not in range(-n, n + 1):
-			raise IndexError(f'Cannot start slice {start} bits into {n}-bit value')
+			err = ToriiIndexError(
+				f'Cannot start slice {start} bits into a(n) {n}-bit value',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
+			if start < -n:
+				err.add_note(
+					f'The start value {start} wants to access the {n - start}-th bit past the minimum start index'
+					f' of -{n}'
+				)
+			elif start > n + 1:
+				err.add_note(
+					f'The start value {start} wants to access the {start - (n + 1)}-th bit past the maximum start'
+					f' index of {n + 1}'
+				)
+
+			err.add_note(
+				'The start index of a Torii slice only wraps once in either direction, this may be changed'
+				' in the future.'
+			)
+
+			raise err
+
 		if start < 0:
 			start += n
+
 		if stop not in range(-n, n + 1):
-			raise IndexError(f'Cannot stop slice {stop} bits into {n}-bit value')
+			err = ToriiIndexError(
+				f'Cannot stop slice {stop} bits into a(n) {n}-bit value',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
+			if stop < -n:
+				err.add_note(
+					f'The start value {stop} wants to access the {n - stop}-th bit past the minimum stop index'
+					f' of -{n}'
+				)
+			elif stop > n + 1:
+				err.add_note(
+					f'The stop value {stop} wants to access the {stop - (n + 1)}-th bit past the maximum stop'
+					f' index of {n + 1}'
+				)
+
+			err.add_note(
+				'The stop index of a Torii slice only wraps once in either direction, this may be changed'
+				' in the future.'
+			)
+
+			raise err
+
 		if stop < 0:
 			stop += n
+
 		if start > stop:
-			raise IndexError(f'Slice start {start} must be less than slice stop {stop}')
+			raise ToriiIndexError(
+				f'Slice start {start} must be less than slice stop {stop}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
 		super().__init__(src_loc_at = src_loc_at)
 		self.value = value

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1030,7 +1030,7 @@ class Value(metaclass = ABCMeta):
 		return Assign(self, self - value, src_loc_at = 1 + src_loc_at)
 
 	@abstractmethod
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		'''
 		Bit width and signedness of a value.
 
@@ -1181,8 +1181,8 @@ class Const(Value, metaclass = _ConstMeta):
 		self.signed = shape.signed
 		self.value  = self.normalize(self.value, shape)
 
-	def shape(self) -> Shape:
-		return Shape(self.width, self.signed, src_loc_at = 1)
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return Shape(self.width, self.signed, src_loc_at = 1 + src_loc_at)
 
 	def _rhs_signals(self) -> SignalSet:
 		'''
@@ -1209,7 +1209,7 @@ class Operator(Value):
 		self.operator = operator
 		self.operands = [ Value.cast(op) for op in operands ]
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		def _bitwise_binary_shape(a_shape: Shape, b_shape: Shape) -> Shape:
 			if not a_shape.signed and not b_shape.signed:
 				# both operands unsigned
@@ -1335,8 +1335,8 @@ class Slice(Value):
 		self.start = int(operator.index(start))
 		self.stop  = int(operator.index(stop))
 
-	def shape(self) -> Shape:
-		return Shape(self.stop - self.start)
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return Shape(self.stop - self.start, src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> SignalSet | ValueSet:
 		return self.value._lhs_signals()
@@ -1373,8 +1373,8 @@ class Part(Value):
 		self.width  = width
 		self.stride = stride
 
-	def shape(self) -> Shape:
-		return Shape(self.width)
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return Shape(self.width, src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> SignalSet | ValueSet:
 		return self.value._lhs_signals()
@@ -1442,8 +1442,8 @@ class Cat(Value):
 			# NOTE(aki): Type inference is scrambled by the check above, so as painful as it is we ignore it
 			self.parts.append(Value.cast(arg, src_loc_at = 1 + src_loc_at)) # type: ignore
 
-	def shape(self) -> Shape:
-		return Shape(sum(len(part) for part in self.parts))
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return Shape(sum(len(part) for part in self.parts), src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> SignalSet | ValueSet:
 		return union((part._lhs_signals() for part in self.parts), start = SignalSet())
@@ -1647,8 +1647,8 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 		# NOTE(aki): mypy will complain about this due to the param expansion
 		return Signal(**kw, src_loc_at = 1 + src_loc_at) # type: ignore
 
-	def shape(self) -> Shape:
-		return Shape(self.width, self.signed)
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return Shape(self.width, self.signed, src_loc_at = 1 + src_loc_at)
 
 	def _lhs_signals(self) -> SignalSet:
 		return SignalSet((self,))
@@ -1707,7 +1707,7 @@ class ClockSignal(Value):
 
 		self.domain = domain
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		return Shape(1)
 
 	def _lhs_signals(self) -> SignalSet:
@@ -1771,7 +1771,7 @@ class ResetSignal(Value):
 		self.domain = domain
 		self.allow_reset_less = allow_reset_less
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		return Shape(1)
 
 	def _lhs_signals(self) -> SignalSet:
@@ -1801,7 +1801,7 @@ class AnyValue(Value, DUID):
 		self.width  = self._shape.width
 		self.signed = self._shape.signed
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		return self._shape
 
 	def _rhs_signals(self) -> SignalSet:
@@ -1950,7 +1950,7 @@ class ArrayProxy(Value):
 	def _iter_as_values(self):
 		return (Value.cast(elem) for elem in self.elems)
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		unsigned_width = signed_width = 0
 		has_unsigned = has_signed = False
 		for elem_shape in (elem.shape() for elem in self._iter_as_values()):
@@ -2187,8 +2187,8 @@ class Sample(Value):
 				src_loc = self.src_loc
 			)
 
-	def shape(self) -> Shape:
-		return self.value.shape()
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
+		return self.value.shape(src_loc_at = 1 + src_loc_at)
 
 	def _rhs_signals(self) -> ValueSet:
 		return ValueSet((self,))
@@ -2396,7 +2396,7 @@ class Initial(Value):
 	def __init__(self, *, src_loc_at: int = 0) -> None:
 		super().__init__(src_loc_at = src_loc_at)
 
-	def shape(self) -> Shape:
+	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		return Shape(1)
 
 	def _rhs_signals(self) -> ValueSet:

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1438,14 +1438,25 @@ class Part(Value):
 		src_loc_at: int = 0
 	) -> None:
 		if not isinstance(width, int) or width < 0:
-			raise TypeError(f'Part width must be a non-negative integer, not {width!r}')
-		if not isinstance(stride, int) or stride <= 0:
-			raise TypeError(f'Part stride must be a positive integer, not {stride!r}')
+			raise ToriiSyntaxError(
+				f'Part width must be a non-negative integer, not {width!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
-		value  = Value.cast(value)
-		offset = Value.cast(offset)
+		if not isinstance(stride, int) or stride <= 0:
+			raise ToriiSyntaxError(
+				f'Part stride must be a positive non-zero integer, not {stride!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
+		value  = Value.cast(value, src_loc_at = 1 + src_loc_at)
+		offset = Value.cast(offset, src_loc_at = 1 + src_loc_at)
+
 		if offset.shape().signed:
-			raise TypeError('Part offset must be unsigned')
+			raise ToriiSyntaxError(
+				'Part offset must be unsigned',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
 		super().__init__(src_loc_at = src_loc_at)
 		self.value  = value

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2351,10 +2351,20 @@ class Sample(Value):
 			)
 
 		if self.domain is not None and (self.domain == '' or not _check_name(self.domain)):
-			raise ToriiSyntaxError(
-				'Sample domain name must not be empty or contain any control or whitespace characters',
-				src_loc = self.src_loc
+			err = ToriiSyntaxError(
+				'Sample domain names may not be empty or contain any control or whitespace characters',
+				self.src_loc,
 			)
+
+			if self.domain == '':
+				err.add_note('An empty string was provided to the `domain` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, Zs,'
+					' Zl, Zp'
+				)
+
+			raise err
 
 	def shape(self, *, src_loc_at: int = 0) -> Shape:
 		return self.value.shape(src_loc_at = 1 + src_loc_at)

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -359,7 +359,7 @@ def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
 			)
 		if key < 0:
 			key += n
-		return Slice(value, key, key + 1, src_loc_at = 1)
+		return Slice(value, key, key + 1, src_loc_at = 2)
 	elif isinstance(key, slice):
 		if isinstance(key.start, Value) or isinstance(key.stop, Value):
 			raise ToriiSyntaxError(
@@ -369,8 +369,8 @@ def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
 			)
 		start, stop, step = key.indices(n)
 		if step != 1:
-			return Cat(*(value[i] for i in range(start, stop, step)))
-		return Slice(value, start, stop, src_loc_at = 1)
+			return Cat(*(value[i] for i in range(start, stop, step)), src_loc_at = 2)
+		return Slice(value, start, stop, src_loc_at = 2)
 	elif isinstance(key, Value):
 		raise ToriiSyntaxError(
 			'Indexing a value with another value is not supported, use `Value.bit_select()` instead.',

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -352,24 +352,34 @@ def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
 	n = len(value)
 	if isinstance(key, int):
 		if key not in range(-n, n):
-			raise IndexError(f'Index {key} is out of bounds for a {n}-bit value')
+			raise ToriiSyntaxError(
+				f'Index {key} is out of bounds for a {n}-bit value',
+				tracer.get_src_loc(src_loc_at = 1)
+			)
 		if key < 0:
 			key += n
 		return Slice(value, key, key + 1, src_loc_at = 1)
 	elif isinstance(key, slice):
 		if isinstance(key.start, Value) or isinstance(key.stop, Value):
-			raise SyntaxError(
+			raise ToriiSyntaxError(
 				'Slicing a value with a Value is unsupported, '
-				'use `Value.bit_select()` or `Value.word_select()` instead.'
+				'use `Value.bit_select()` or `Value.word_select()` instead.',
+				tracer.get_src_loc(src_loc_at = 1)
 			)
 		start, stop, step = key.indices(n)
 		if step != 1:
 			return Cat(*(value[i] for i in range(start, stop, step)))
 		return Slice(value, start, stop, src_loc_at = 1)
 	elif isinstance(key, Value):
-		raise SyntaxError('Indexing a value with another value is not supported, use `Value.bit_select()` instead.')
+		raise ToriiSyntaxError(
+			'Indexing a value with another value is not supported, use `Value.bit_select()` instead.',
+			tracer.get_src_loc(src_loc_at = 1)
+		)
 	else:
-		raise TypeError(f'Cannot index value with {key!r}')
+		raise ToriiSyntaxError(
+			f'Cannot index value with {key!r}',
+			tracer.get_src_loc(src_loc_at = 1)
+		)
 
 class Value(metaclass = ABCMeta):
 	'''

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2986,7 +2986,7 @@ class ValueKey:
 	'''
 
 	def __init__(self, value: ValueCastT) -> None:
-		self.value = Value.cast(value)
+		self.value = Value.cast(value, src_loc_at = 1)
 		if isinstance(self.value, Const):
 			self._hash = hash(self.value.value)
 		elif isinstance(self.value, (Signal, AnyValue)):
@@ -3017,7 +3017,14 @@ class ValueKey:
 		elif isinstance(self.value, Initial):
 			self._hash = 0
 		else: # :nocov:
-			raise TypeError(f'Object {self.value!r} cannot be used as a key in value collections')
+			raise ToriiSyntaxError(
+				f'Object of type {type(self.value).__name__} cannot be used as a key in Torii value collections',
+				tracer.get_src_loc(),
+				notes = [
+					'The following types of objects are supported as Value keys: Const, Signal, AnyValue, ClockSignal,'
+					' ResetSignal, Operator, Slice, Part, Cat, ArrayProxy, Sample, Initial'
+				]
+			)
 
 	def __hash__(self) -> int:
 		return self._hash
@@ -3102,7 +3109,14 @@ class ValueKey:
 
 			return True
 		else: # :nocov:
-			raise TypeError(f'Object {self.value!r} cannot be used as a key in value collections')
+			raise ToriiSyntaxError(
+				f'Object of type {type(self.value).__name__} cannot be used as a key in Torii value collections',
+				tracer.get_src_loc(),
+				notes = [
+					'The following types of objects are supported as Value keys: Const, Signal, AnyValue, ClockSignal,'
+					' ResetSignal, Operator, Slice, Part, Cat, ArrayProxy, Sample, Initial'
+				]
+			)
 
 	def __lt__(self, other: ValueKey) -> bool | Operator:
 		if not isinstance(other, ValueKey):
@@ -3126,7 +3140,14 @@ class ValueKey:
 				self.value.stop < other.value.stop
 			)
 		else: # :nocov:
-			raise TypeError(f'Object {other!r} cannot be used as a key in value collections')
+			raise ToriiSyntaxError(
+				f'Object of type {type(self.value).__name__} cannot be used as a key in Torii value collections',
+				tracer.get_src_loc(),
+				notes = [
+					'The following types of objects are supported as Value keys: Const, Signal, AnyValue, ClockSignal,'
+					' ResetSignal, Operator, Slice, Part, Cat, ArrayProxy, Sample, Initial'
+				]
+			)
 
 	def __repr__(self) -> str:
 		return f'<{__name__}.ValueKey {self.value!r}>'

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1024,7 +1024,7 @@ class Const(Value, metaclass = _ConstMeta):
 		return value
 
 	@staticmethod
-	def cast(obj: ValueCastT) -> Const:
+	def cast(obj: ValueCastT, *, src_loc_at: int = 0) -> Const:
 		'''
 		Converts ``obj`` to an Torii constant.
 

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1431,7 +1431,7 @@ class Cat(Value):
 				)
 
 			# NOTE(aki): Type inference is scrambled by the check above, so as painful as it is we ignore it
-			self.parts.append(Value.cast(arg)) # type: ignore
+			self.parts.append(Value.cast(arg, src_loc_at = 1 + src_loc_at)) # type: ignore
 
 	def shape(self) -> Shape:
 		return Shape(sum(len(part) for part in self.parts))

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -345,7 +345,7 @@ def _overridable_by_swapping(method_name: str):
 		return wrapper
 	return decorator
 
-def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
+def _index_valuelike(value: Value | ValueCastable, key: object, src_loc_at: int = 0) -> Value:
 	'''
 	.. todo:: Document Me
 	'''
@@ -355,31 +355,31 @@ def _index_valuelike(value: Value | ValueCastable, key: object) -> Value:
 		if key not in range(-n, n):
 			raise ToriiIndexError(
 				f'Index {key} is out of bounds for a {n}-bit value',
-				tracer.get_src_loc(src_loc_at = 1)
+				tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 			)
 		if key < 0:
 			key += n
-		return Slice(value, key, key + 1, src_loc_at = 2)
+		return Slice(value, key, key + 1, src_loc_at = 2 + src_loc_at)
 	elif isinstance(key, slice):
 		if isinstance(key.start, Value) or isinstance(key.stop, Value):
 			raise ToriiSyntaxError(
 				'Slicing a value with a Value is unsupported, '
 				'use `Value.bit_select()` or `Value.word_select()` instead.',
-				tracer.get_src_loc(src_loc_at = 1)
+				tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 			)
 		start, stop, step = key.indices(n)
 		if step != 1:
-			return Cat(*(value[i] for i in range(start, stop, step)), src_loc_at = 2)
-		return Slice(value, start, stop, src_loc_at = 2)
+			return Cat(*(value[i] for i in range(start, stop, step)), src_loc_at = 2 + src_loc_at)
+		return Slice(value, start, stop, src_loc_at = 2 + src_loc_at)
 	elif isinstance(key, Value):
 		raise ToriiSyntaxError(
 			'Indexing a value with another value is not supported, use `Value.bit_select()` instead.',
-			tracer.get_src_loc(src_loc_at = 1)
+			tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 		)
 	else:
 		raise ToriiSyntaxError(
 			f'Cannot index value with {key!r}',
-			tracer.get_src_loc(src_loc_at = 1)
+			tracer.get_src_loc(src_loc_at = 1 + src_loc_at)
 		)
 
 class Value(metaclass = ABCMeta):
@@ -723,7 +723,7 @@ class Value(metaclass = ABCMeta):
 		offset = Value.cast(offset, src_loc_at = 1 + src_loc_at)
 		if type(offset) is Const and isinstance(width, int):
 			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
-			return _index_valuelike(self, slice(offset.value, offset.value + width))
+			return _index_valuelike(self, slice(offset.value, offset.value + width), src_loc_at = src_loc_at)
 		return Part(self, offset, width, stride = 1, src_loc_at = 1 + src_loc_at)
 
 	def word_select(self, offset: Value | int, width: int, *, src_loc_at: int = 0) -> Value:
@@ -750,7 +750,11 @@ class Value(metaclass = ABCMeta):
 		offset = Value.cast(offset, src_loc_at = 1 + src_loc_at)
 		if type(offset) is Const and isinstance(width, int):
 			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
-			return _index_valuelike(self, slice(offset.value * width, (offset.value + 1) * width))
+			return _index_valuelike(
+				self,
+				slice(offset.value * width, (offset.value + 1) * width),
+				src_loc_at = src_loc_at
+			)
 		return Part(self, offset, width, stride = width, src_loc_at = 1 + src_loc_at)
 
 	def matches(self, *patterns: int | str | EnumMeta, src_loc_at: int = 0) -> Value:
@@ -888,7 +892,7 @@ class Value(metaclass = ABCMeta):
 			return self[amount:].as_signed(src_loc_at = 1 + src_loc_at)
 		else:
 			# NOTE: We use `_index_valuelike` rather than `self[...]` to ensure source locality is correct
-			return _index_valuelike(self, slice(amount, None)) # unsigned
+			return _index_valuelike(self, slice(amount, None), src_loc_at = src_loc_at) # unsigned
 
 	def rotate_left(self, amount: int, *, src_loc_at: int = 0) -> Value:
 		'''

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -315,13 +315,13 @@ class ShapeLike(metaclass = _ShapeLikeMeta):
 	def __new__(cls, *args, **kwargs):
 		raise TypeError('ShapeLike is an abstract class and cannot be constructed')
 
-def unsigned(width: int) -> Shape:
+def unsigned(width: int, *, src_loc_at: int = 0) -> Shape:
 	''' Shorthand for ``Shape(width, signed = False)``. '''
-	return Shape(width, signed = False, src_loc_at = 1)
+	return Shape(width, signed = False, src_loc_at = 1 + src_loc_at)
 
-def signed(width: int) -> Shape:
+def signed(width: int, *, src_loc_at: int = 0) -> Shape:
 	''' Shorthand for ``Shape(width, signed = True)``. '''
-	return Shape(width, signed = True, src_loc_at = 1)
+	return Shape(width, signed = True, src_loc_at = 1 + src_loc_at)
 
 def _overridable_by_swapping(method_name: str):
 	'''

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -17,7 +17,7 @@ from typing            import (
 	TYPE_CHECKING, Generic, Literal, NoReturn, ParamSpec, SupportsIndex, TypeAlias, TypeVar, TypeVarTuple,
 )
 
-from ..diagnostics     import ToriiSyntaxError, ToriiSyntaxWarning, UnusedProperty
+from ..diagnostics     import ToriiError, ToriiSyntaxError, ToriiSyntaxWarning, UnusedProperty
 from ..diagnostics     import IndexError as ToriiIndexError
 from .._typing         import SrcLoc, SwitchCaseT
 from ..util            import _check_name, flatten, tracer, union
@@ -2171,17 +2171,28 @@ class ValueCastable:
 	#            a sane way to keep that check but also let us properly type as_value and as_shape
 	def __init_subclass__(cls, **kwargs):
 		if not hasattr(cls, 'as_value'):
-			raise TypeError(
-				f'Class \'{cls.__name__}\' deriving from `ValueCastable` must override the `as_value` method'
+			raise ToriiError(
+				message = (
+					f'The class \'{cls.__name__}\' which derives from \'ValueCastable\' must provide an override'
+					' for the \'ValueCastable.as_value\' method'
+				),
+				src_loc = tracer.get_src_loc()
 			)
 		if not hasattr(cls, 'shape'):
-			raise TypeError(
-				f'Class \'{cls.__name__}\' deriving from `ValueCastable` must override the `shape` method'
+			raise ToriiError(
+				message = (
+					f'The class \'{cls.__name__}\' which derives from \'ValueCastable\' must provide an override'
+					' for the \'ValueCastable.shape\' method'
+				),
+				src_loc = tracer.get_src_loc()
 			)
 		if not hasattr(cls.as_value, '_ValueCastable__memoized'):
-			raise TypeError(
-				f'Class \'{cls.__name__}\' deriving from `ValueCastable` must decorate '
-				'the `as_value` method with the `ValueCastable.lowermethod` decorator'
+			raise ToriiError(
+				message = (
+					f'The class \'{cls.__name__}\' which derives from \'ValueCastable\' must decorate'
+					' the overridden \'ValueCastable.as_value\' method with the \'ValueCastable.lowermethod\' decorator'
+				),
+				src_loc = tracer.get_src_loc()
 			)
 
 	@staticmethod

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -148,13 +148,24 @@ class Shape:
 
 	'''  # noqa: E101
 
-	def __init__(self, width: int = 1, signed: bool = False) -> None:
+	def __init__(self, width: int = 1, signed: bool = False, *, src_loc_at: int = 0) -> None:
 		if not isinstance(width, int):
-			raise TypeError(f'Width must be an integer, not {width!r}')
+			raise ToriiSyntaxError(
+				f'The width of a value must be an integer, not {width!r}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if not signed and width < 0:
-			raise ValueError(f'Width of an unsigned value must be zero or a positive integer, not {width}')
+			raise ToriiSyntaxError(
+				f'The width of an unsigned value must be zero or a positive integer, not {width}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if signed and width <= 0:
-			raise ValueError(f'Width of a signed value must be a positive integer, not {width}')
+			raise ToriiSyntaxError(
+				f'The width of a signed value must be a non-zero positive integer, not {width}',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
 		self.width = width
 		self.signed = signed
@@ -162,7 +173,7 @@ class Shape:
 	# This implements an algorithm for inferring shape from standard Python enumerations
 	# for `Shape.cast()`.
 	@staticmethod
-	def _cast_plain_enum(obj: EnumMeta) -> Shape:
+	def _cast_plain_enum(obj: EnumMeta, src_loc_at: int) -> Shape:
 		'''
 		.. todo:: Document Me
 		'''
@@ -176,10 +187,16 @@ class Shape:
 			try:
 				member_shape = Const.cast(member.value).shape() # type: ignore
 			except TypeError:
-				raise TypeError(
+				raise ToriiSyntaxError(
 					'Only enumerations whose members have constant-castable '
-					'values can be used in Torii code'
+					'values can be used in Torii code',
+					tracer.get_src_loc(src_loc_at = src_loc_at),
+					notes = [
+						f'The enum entry \'{member.name}\' has the {type(member.value).__name__} value '
+						f'\'{member.value}\', which is not Torii const-castable'
+					]
 				)
+
 			if not signed and member_shape.signed:
 				signed = True
 				width  = max(width + 1, member_shape.width)
@@ -187,6 +204,7 @@ class Shape:
 				width  = max(width, member_shape.width + 1)
 			else:
 				width  = max(width, member_shape.width)
+
 		return Shape(width, signed)
 
 	@staticmethod
@@ -201,7 +219,7 @@ class Shape:
 			elif isinstance(obj, ShapeCastable):
 				new_obj = obj.as_shape()
 			elif isinstance(obj, int):
-				return Shape(obj)
+				return Shape(obj, src_loc_at = 1 + src_loc_at)
 			elif isinstance(obj, range):
 				if len(obj) == 0:
 					return Shape(0)
@@ -212,13 +230,21 @@ class Shape:
 				)
 				if obj[0] == obj[-1] == 0:
 					width = 0
-				return Shape(width, signed)
+				return Shape(width, signed, src_loc_at = 1 + src_loc_at)
 			elif isinstance(obj, type) and issubclass(obj, Enum):
-				return Shape._cast_plain_enum(obj)
+				return Shape._cast_plain_enum(obj, src_loc_at = 1 + src_loc_at)
 			else:
-				raise TypeError(f'Object {obj!r} cannot be converted to a Torii shape')
+				raise ToriiSyntaxError(
+					f'Object {obj!r} cannot be converted to a Torii shape',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
+
 			if new_obj is obj:
-				raise RecursionError(f'Shape-castable object {obj!r} casts to itself')
+				raise ToriiSyntaxError(
+					f'Shape-castable object {obj!r} casts to itself',
+					tracer.get_src_loc(src_loc_at = src_loc_at)
+				)
+
 			obj = new_obj
 
 	def __repr__(self) -> str:
@@ -230,9 +256,12 @@ class Shape:
 	def __eq__(self, other: object) -> bool:
 		if not isinstance(other, Shape):
 			try:
-				other = self.__class__.cast(other)
-			except TypeError as e:
-				raise TypeError(f'Shapes may be compared with shape-castable objects, not {other!r}') from e
+				other = self.__class__.cast(other, src_loc_at = 1)
+			except ToriiSyntaxError as e:
+				raise ToriiSyntaxError(
+					f'Shapes may be compared with shape-castable objects, not {other!r}',
+					tracer.get_src_loc()
+				) from e
 
 		return self.width == other.width and self.signed == other.signed
 
@@ -287,11 +316,11 @@ class ShapeLike(metaclass = _ShapeLikeMeta):
 
 def unsigned(width: int) -> Shape:
 	''' Shorthand for ``Shape(width, signed = False)``. '''
-	return Shape(width, signed = False)
+	return Shape(width, signed = False, src_loc_at = 1)
 
 def signed(width: int) -> Shape:
 	''' Shorthand for ``Shape(width, signed = True)``. '''
-	return Shape(width, signed = True)
+	return Shape(width, signed = True, src_loc_at = 1)
 
 def _overridable_by_swapping(method_name: str):
 	'''
@@ -351,7 +380,7 @@ class Value(metaclass = ABCMeta):
 	''' .. todo:: Document Me '''
 
 	@staticmethod
-	def cast(obj: ValueCastT) -> Value:
+	def cast(obj: ValueCastT, *, src_loc_at: int = 0) -> Value:
 		'''
 		Converts ``obj`` to an Torii value.
 
@@ -367,7 +396,7 @@ class Value(metaclass = ABCMeta):
 				# NOTE(aki): See TODO on `ValueCastable.__init_subclass__`
 				new_obj = obj.as_value() # type: ignore
 			elif isinstance(obj, Enum):
-				return Const(obj.value, Shape.cast(type(obj)))
+				return Const(obj.value, Shape.cast(type(obj), src_loc_at = 1 + src_loc_at))
 			elif isinstance(obj, int):
 				return Const(obj)
 			else:
@@ -1024,9 +1053,9 @@ class Const(Value, metaclass = _ConstMeta):
 		# We deliberately do not call Value.__init__ here.
 		self.value = int(operator.index(value))
 		if shape is None:
-			shape = Shape(bits_for(self.value), signed = self.value < 0)
+			shape = Shape(bits_for(self.value), signed = self.value < 0, src_loc_at = 1 + src_loc_at)
 		elif isinstance(shape, int):
-			shape = Shape(shape, signed = self.value < 0)
+			shape = Shape(shape, signed = self.value < 0, src_loc_at = 1 + src_loc_at)
 		else:
 			if isinstance(shape, range) and self.value == shape.stop:
 				warnings.warn(
@@ -1413,7 +1442,7 @@ class Signal(Value, DUID, Generic[*_SigParams]):
 		else:
 			try:
 				reset_val = Const.cast(reset or 0)
-			except TypeError:
+			except ToriiSyntaxError:
 				raise TypeError(
 					f'Reset value must be a constant-castable expression, not {reset!r}'
 				)

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -1136,22 +1136,25 @@ class Const(Value, metaclass = _ConstMeta):
 			value = 0
 			width = 0
 			for part in obj.parts:
-				const  = Const.cast(part)
-				part_value = Const(const.value, unsigned(const.width)).value
+				const  = Const.cast(part, src_loc_at = 1 + src_loc_at)
+				part_value = Const(const.value, unsigned(const.width), src_loc_at = 1 + src_loc_at).value
 				value |= part_value << width
 				width += len(const)
-			return Const(value, width)
+			return Const(value, width, src_loc_at = 1 + src_loc_at)
 		elif type(obj) is Slice:
 			# NOTE(aki): mypy leaks type of `value` from above `elif`
-			value = Const.cast(obj.value) # type: ignore
+			value = Const.cast(obj.value, src_loc_at = 1 + src_loc_at) # type: ignore
 
 			# Do type coercion
 			if TYPE_CHECKING:
 				assert isinstance(value, Const)
 
-			return Const(value.value >> obj.start, unsigned(obj.stop - obj.start))
+			return Const(value.value >> obj.start, unsigned(obj.stop - obj.start), src_loc_at = 1 + src_loc_at)
 		else:
-			raise TypeError(f'Value {obj!r} cannot be converted to an Torii constant')
+			raise ToriiSyntaxError(
+				f'Value {obj!r} cannot be converted to a Torii constant',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
 
 	def __init__(
 		self, value: int, shape: Shape | int | range | type | ShapeCastable | None = None, *,
@@ -1171,7 +1174,7 @@ class Const(Value, metaclass = _ConstMeta):
 					f'Value {self.value!r} equals the non-inclusive end of the constant '
 					f'shape {shape!r}; this is likely an off-by-one error',
 					category = ToriiSyntaxWarning,
-					stacklevel = 3
+					stacklevel = 2 + src_loc_at
 				)
 			shape = Shape.cast(shape, src_loc_at = 1 + src_loc_at)
 		self.width  = shape.width
@@ -1179,7 +1182,7 @@ class Const(Value, metaclass = _ConstMeta):
 		self.value  = self.normalize(self.value, shape)
 
 	def shape(self) -> Shape:
-		return Shape(self.width, self.signed)
+		return Shape(self.width, self.signed, src_loc_at = 1)
 
 	def _rhs_signals(self) -> SignalSet:
 		'''

--- a/torii/hdl/ast.py
+++ b/torii/hdl/ast.py
@@ -2680,15 +2680,31 @@ class Property(Statement, MustUse):
 	) -> None:
 		super().__init__(src_loc_at = src_loc_at)
 		self.kind   = self.Kind(kind)
-		self.test   = Value.cast(test)
+		self.test   = Value.cast(test, src_loc_at = 1 + src_loc_at)
 
 		self.name   = name
 
 		if not isinstance(self.name, str) and self.name is not None:
-			raise TypeError(f'Property name must be a string of None, not {self.name!r}')
+			raise ToriiSyntaxError(
+				f'Property names must be a string or None, not {self.name!r}',
+				self.src_loc
+			)
 
 		if self.name is not None and (self.name == '' or not _check_name(self.name)):
-			raise NameError('Property name must not be empty or contain any control or whitespace characters')
+			err = ToriiSyntaxError(
+				'Property names may not be empty or contain any control or whitespace characters',
+				self.src_loc,
+			)
+
+			if name == '':
+				err.add_note('An empty string was provided to the `name` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, Zs,'
+					' Zl, Zp'
+				)
+
+			raise err
 
 		if _check is None:
 			self._check: Signal = Signal(reset_less = True, name = f'${self.kind.value}$check')

--- a/torii/hdl/cd.py
+++ b/torii/hdl/cd.py
@@ -2,7 +2,7 @@
 
 from typing        import Literal
 
-from ..diagnostics import NameNotFound
+from ..diagnostics import NameNotFound, ToriiSyntaxError
 from ..util        import _check_name, tracer
 from .ast          import Signal
 
@@ -68,18 +68,41 @@ class ClockDomain:
 			try:
 				name = tracer.get_var_name()
 			except NameNotFound:
-				raise ValueError('Clock domain name must be specified explicitly')
+				raise ToriiSyntaxError(
+					'The name for this clock domain could not be automatically determined and no name was explicitly '
+					'specified',
+					self.src_loc,
+				)
 
 		if name == '' or not _check_name(name):
-			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+			err = ToriiSyntaxError(
+				'The name specified for this clock domain must not be empty or contain any control/whitespace '
+				'characters',
+				self.src_loc,
+			)
+
+			if name == '':
+				err.add_note('An empty string was provided to the `name` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, Zs, Zl, Zp'
+				)
+
+			raise err
 
 		if name.startswith('cd_'):
 			name = name[3:]
 		if name == 'comb':
-			raise ValueError(f'Domain \'{name}\' may not be clocked')
+			raise ToriiSyntaxError(
+				'The combinatorial logic domain \'comb\' may not be clocked',
+				self.src_loc
+			)
 
 		if clk_edge not in ('pos', 'neg'):
-			raise ValueError(f'Domain clock edge must be one of \'pos\' or \'neg\', not {clk_edge!r}')
+			raise ToriiSyntaxError(
+				f'Domain clock edge must be one of \'pos\' or \'neg\', not {clk_edge!r}',
+				self.src_loc
+			)
 
 		self.name = name
 
@@ -101,7 +124,20 @@ class ClockDomain:
 		'''
 
 		if new_name == '' or not _check_name(new_name):
-			raise NameError('Clock domain name must not be empty or contain any control or whitespace characters')
+			err = ToriiSyntaxError(
+				'The name specified for this clock domain must not be empty or contain any control/whitespace '
+				'characters',
+				self.src_loc,
+			)
+
+			if new_name == '':
+				err.add_note('An empty string was provided to the `name` parameter, was this intentional?')
+			else:
+				err.add_note(
+					'A character in the name was in one of the following Unicode groups: Cc, Cf, Cs, Co, Cn, Zs, Zl, Zp'
+				)
+
+			raise err
 
 		self.name = new_name
 		self.clk.name = self._name_for(new_name, 'clk')

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -514,7 +514,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 				orig_pattern = pattern
 				try:
 					pattern = Const.cast(pattern)
-				except TypeError as error:
+				except ToriiSyntaxError as error:
 					raise ToriiSyntaxError(
 						'Case pattern must be a string or a const-castable expression, '
 						f'not {pattern!r}',

--- a/torii/hdl/rec.py
+++ b/torii/hdl/rec.py
@@ -291,8 +291,8 @@ class Record(ValueCastable):
 			name = '<unnamed>'
 		return f'(rec {name} {" ".join(fields)})'
 
-	def shape(self):
-		return self.as_value().shape()
+	def shape(self, *, src_loc_at: int = 0):
+		return self.as_value().shape(src_loc_at = 1 + src_loc_at)
 
 	def connect(self, *subordinates, include = None, exclude = None):
 		'''

--- a/torii/hdl/rec.py
+++ b/torii/hdl/rec.py
@@ -9,6 +9,7 @@ from functools       import reduce, wraps
 from inspect         import get_annotations, isclass
 from typing          import Any, TypeAlias, get_args, get_origin
 
+from ..diagnostics   import ToriiSyntaxError
 from ..util          import _check_name, tracer, union
 from .ast            import Cat, Shape, ShapeCastT, Signal, SignalSet, Value, ValueCastable
 
@@ -352,7 +353,15 @@ def _valueproxy(name):
 
 	@wraps(value_func)
 	def _wrapper(self, *args, **kwargs):
-		return value_func(Value.cast(self), *args, **kwargs)
+		try:
+			return value_func(Value.cast(self), *args, **kwargs)
+		except ToriiSyntaxError as err:
+			# Fixup the source locality information due to the value proxy call
+			src_loc = tracer.get_src_loc()
+			err.filename = src_loc[0]
+			err.lineno = src_loc[1]
+
+			raise err
 
 	return _wrapper
 

--- a/torii/hdl/xfrm.py
+++ b/torii/hdl/xfrm.py
@@ -456,7 +456,14 @@ class FragmentTransformer:
 			value._transforms_.append(self)
 			return value
 		else:
-			raise AttributeError(f'Object {value!r} cannot be elaborated')
+			raise ToriiSyntaxError(
+				f'Objects of type \'{type(value)}\' can not be elaborated',
+				tracer.get_src_loc(src_loc_at = 1 + src_loc_at),
+				notes = [
+					'Only Torii objects of type \'Elaboratable\', \'Fragment\', and \'Module\', or objects which'
+					' have them as a superclass may be elaborated'
+				]
+			)
 
 class TransformedElaboratable(Elaboratable):
 	'''

--- a/torii/hdl/xfrm.py
+++ b/torii/hdl/xfrm.py
@@ -7,6 +7,7 @@ from copy            import copy
 
 from ..diagnostics   import DomainError, NonSynthesizableError, ToriiSyntaxError
 from ..util          import flatten, tracer
+from ..util.string   import _get_best_matching
 from .ast            import (
 	AnyValue, ArrayProxy, Assign, Cat, ClockSignal, Const, Initial, Mux, Operator, Part, Property, ResetSignal, Sample,
 	Signal, SignalDict, SignalSet, Slice, Statement, Switch, Value, ValueDict, _StatementList,
@@ -707,7 +708,28 @@ class DomainLowerer(FragmentTransformer, ValueTransformer, StatementTransformer)
 		'''
 
 		if domain not in self.domains:
-			raise DomainError(f'Signal {context!r} refers to nonexistent domain \'{domain}\'')
+			matches = _get_best_matching(domain, self.domains.keys())
+			additional_ctx = None
+
+			if len(matches) > 0:
+				match = matches[0]
+				message = (
+					f'The signal {context!r} refers to a nonexistent clock domain \'{domain}\', did you mean'
+					f' \'{match}\'?'
+				)
+
+				additional_ctx = (
+					f'The clock domain \'{match}\' was defined here:',
+					self.domains[match].src_loc
+				)
+
+			else:
+				message = f'The signal {context!r} refers to nonexistent domain \'{domain}\''
+
+			raise DomainError(
+				message = message, src_loc = context.src_loc, additional_ctx = additional_ctx
+			)
+
 		return self.domains[domain]
 
 	def map_drivers(self, fragment, new_fragment):
@@ -727,7 +749,10 @@ class DomainLowerer(FragmentTransformer, ValueTransformer, StatementTransformer)
 			if value.allow_reset_less:
 				return Const(0)
 			else:
-				raise DomainError(f'Signal {value!r} refers to reset of reset-less domain \'{value.domain}\'')
+				raise DomainError(
+					message = f'Signal {value!r} refers to reset of reset-less domain \'{value.domain}\'',
+					src_loc = value.src_loc
+				)
 		return domain.rst
 
 	def _insert_resets(self, fragment):

--- a/torii/hdl/xfrm.py
+++ b/torii/hdl/xfrm.py
@@ -465,8 +465,13 @@ class TransformedElaboratable(Elaboratable):
 
 	def __init__(self, elaboratable, *, src_loc_at = 0) -> None:
 		if not hasattr(elaboratable, 'elaborate'):
-			raise TypeError(
-				f'Unable to elaborate object of type \'{type(elaboratable)}\' which has no \'elaborate\' method'
+			raise ToriiSyntaxError(
+				f'Objects of type \'{type(elaboratable)}\' can not be elaborated',
+				tracer.get_src_loc(src_loc_at = src_loc_at),
+				notes = [
+					'Only Torii objects of type \'Elaboratable\', \'Fragment\', and \'Module\', or objects which'
+					' have them as a superclass may be elaborated'
+				]
 			)
 
 		# Fields prefixed and suffixed with underscore to avoid as many conflicts with the inner

--- a/torii/hdl/xfrm.py
+++ b/torii/hdl/xfrm.py
@@ -5,7 +5,7 @@ from collections     import OrderedDict
 from collections.abc import Iterable
 from copy            import copy
 
-from ..diagnostics   import DomainError, NonSynthesizableError
+from ..diagnostics   import DomainError, NonSynthesizableError, ToriiSyntaxError
 from ..util          import flatten, tracer
 from .ast            import (
 	AnyValue, ArrayProxy, Assign, Cat, ClockSignal, Const, Initial, Mux, Operator, Part, Property, ResetSignal, Sample,
@@ -631,11 +631,22 @@ class DomainRenamer(FragmentTransformer, ValueTransformer, StatementTransformer)
 		When trying to rename a domain to/from ``comb`` to any other domain.
 	'''
 
-	def __init__(self, **kwargs: str) -> None:
+	def __init__(self, src_loc_at: int = 0, **kwargs: str) -> None:
 		if 'comb' in kwargs.keys():
-			raise ValueError(f'The combinatorial domain \'comb\' may not be renamed to \'{kwargs["comb"]}\'')
+			raise ToriiSyntaxError(
+				f'The combinatorial logic domain \'comb\' may not be renamed to the domain \'{kwargs["comb"]}\'',
+				tracer.get_src_loc(src_loc_at = src_loc_at)
+			)
+
 		if 'comb' in kwargs.values():
-			raise ValueError('Domains may not be renamed to the combinatorial domain \'comb\'')
+			to_comb = ', '.join(map(lambda p: p[0], filter(lambda p: p[1] == 'comb', kwargs.items())))
+			raise ToriiSyntaxError(
+				'Synchronous logic domains may not be renamed to the combinatorial logic domain \'comb\'',
+				tracer.get_src_loc(src_loc_at = src_loc_at),
+				notes = [
+					f'The following domains were being re-assigned: {to_comb}'
+				]
+			)
 
 		self.domain_map = OrderedDict(**kwargs)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This fairly chunky PR fleshes out all the diagnostics in the `torii.hdl.ast` module, polishing them up where possible and threading source locality information throughout.

I don't have screenshots of all the improvements, because oh gosh there are a lot of them, but this should make using anything from the `ast` module much nicer, and also lets us properly adjust source locality information for things that use the elements therein.

This means that the likelihood of an exception traceback to some error condition from user code will no longer show up in the guts of Torii, leading the user to confusion.

The wording for the messages is not amazing, but it's something at least, and can be adjusted and reworked later on, either way this is a large step forward into getting every single bit of the Torii surface area to have proper and well reasoned diagnostics.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
