### PR TITLE
Diagnostics Improvements: `torii.hdl.dsl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Unreleased template stuff
 - The `torii.build.plat` `get_*` functions now take in the list of pin names when generating buffers, to allow for special casing on pin sites as needed.
 - The `torii.lib.io.Pin` record now exposes `i_p`/`i_n` members for input `DiffPairs` and `o_p`/`o_n` members for output `DiffPairs`.
 - The name `submodule` and its plural `submodules` are now explicitly rejected if used as a name for a clock domain.
+- The name `submodule` and its plural `submodules` are now explicitly rejected if used as a name for a submodule instance.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Unreleased template stuff
 - The `torii.build.plat` module now has a `PinFeature` enum which replaces the strings used to pass to the `_check_feature` calls for platform implementation.
 - The `torii.build.plat` `get_*` functions now take in the list of pin names when generating buffers, to allow for special casing on pin sites as needed.
 - The `torii.lib.io.Pin` record now exposes `i_p`/`i_n` members for input `DiffPairs` and `o_p`/`o_n` members for output `DiffPairs`.
+- The name `submodule` and its plural `submodules` are now explicitly rejected if used as a name for a clock domain.
 
 ### Deprecated
 

--- a/tests/hdl/test_cd.py
+++ b/tests/hdl/test_cd.py
@@ -51,6 +51,19 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 		):
 			ClockDomain('\x14')
 
+	def test_name_forbidden(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodule\' for a clock domain is forbidden \(test_cd\.py, line \d+\)$'
+		):
+			ClockDomain('submodule')
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodules\' for a clock domain is forbidden \(test_cd\.py, line \d+\)$'
+		):
+			ClockDomain('submodules')
+
 	def test_rename_wrong(self):
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
@@ -72,6 +85,19 @@ class ClockDomainTestCase(ToriiTestSuiteCase):
 			r' characters \(test_cd\.py, line \d+\)$'
 		):
 			ClockDomain('meow').rename('\x7F')
+
+	def test_rename_forbidden(self) -> None:
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodule\' for a clock domain is forbidden \(test_cd\.py, line \d+\)$'
+		):
+			ClockDomain('meow').rename('submodule')
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodules\' for a clock domain is forbidden \(test_cd\.py, line \d+\)$'
+		):
+			ClockDomain('meow').rename('submodules')
 
 	def test_edge(self):
 		sync = ClockDomain()

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -113,7 +113,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^\'Module\' object has no attribute \'comb\'; did you mean \'d\.comb\'\? \(test_dsl\.py, line \d+\)$'
+			r'^Access to the combinatorial logic domain \'comb\' and clock domains like \'sync\' must be done'
+			r' through the \'d\' attribute on the module \(test_dsl\.py, line \d+\)$'
 		):
 			m.comb += self.c1.eq(1)
 
@@ -121,7 +122,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^\'Module\' object has no attribute \'sync\'; did you mean \'d\.sync\'\? \(test_dsl\.py, line \d+\)$'
+			r'^Access to the combinatorial logic domain \'comb\' and clock domains like \'sync\' must be done'
+			r' through the \'d\' attribute on the module \(test_dsl\.py, line \d+\)$'
 		):
 			m.sync += self.c1.eq(1)
 
@@ -129,7 +131,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^\'Module\' object has no attribute \'nonexistentattr\' \(test_dsl\.py, line \d+\)$'
+			r'^Module has no attribute named \'nonexistentattr\' \(test_dsl\.py, line \d+\)$'
 		):
 			m.nonexistentattr
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -1099,12 +1099,12 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m1 = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^No submodule named \'foo\' exists \(test_dsl\.py, line \d+\)$'
+			r'^The submodule named \'foo\' does not exist in the current module \(test_dsl\.py, line \d+\)$'
 		):
 			m1.submodules.foo
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^No submodule named \'foo\' exists \(test_dsl\.py, line \d+\)$'
+			r'^The submodule named \'foo\' does not exist in the current module \(test_dsl\.py, line \d+\)$'
 		):
 			m1.submodules['foo']
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -640,7 +640,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Case is not permitted outside of Switch \(test_dsl\.py, line \d+\)$'
+			r'^You are not allowed to use an \'m\.Case\(\.\.\.\)\' outside of an \'m\.Switch\(\.\.\.\)\''
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.Case(1):
 				pass # :nocov:
@@ -649,7 +650,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Default is not permitted outside of Switch \(test_dsl\.py, line \d+\)$'
+			r'^You are not allowed to use an \'m\.Default\(\.\.\.\)\' outside of an \'m\.Switch\(\.\.\.\)\''
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.Default():
 				pass # :nocov:
@@ -683,8 +685,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		with m.Switch(self.s1):
 			with self.assertRaisesRegex(
 				ToriiSyntaxError, (
-					r'^If is not permitted directly inside of Switch; '
-					r'it is permitted inside of Switch Case \(test_dsl\.py, line \d+\)$'
+					r'^An \'m\.If\(\.\.\.\)\' is not permitted directly inside of an \'m\.Switch\(\.\.\.\)\';'
+					r' it is only permitted inside of a\(n\) Switchs \'m\.Case\(\.\.\.\)\' \(test_dsl\.py, line \d+\)$'
 				)
 			):
 				with m.If(self.s2):
@@ -696,7 +698,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 			with m.Case(0):
 				with self.assertRaisesRegex(
 					ToriiSyntaxError,
-					r'^Case is not permitted outside of Switch \(test_dsl\.py, line \d+\)$'
+					r'^You are not allowed to use an \'m\.Case\(\.\.\.\)\' outside of an \'m\.Switch\(\.\.\.\)\''
+					r' \(test_dsl\.py, line \d+\)$'
 				):
 					with m.Case(1):
 						pass # :nocov:
@@ -952,8 +955,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 				pass
 			with self.assertRaisesRegex(
 				ToriiSyntaxError, (
-					r'^If is not permitted directly inside of FSM; '
-					r'it is permitted inside of FSM State \(test_dsl\.py, line \d+\)$'
+					r'^An \'m\.If\(\.\.\.\)\' is not permitted directly inside of an \'m\.FSM\(\.\.\.\)\';'
+					r' it is only permitted inside of a\(n\) FSMs \'m\.State\(\.\.\.\)\' \(test_dsl\.py, line \d+\)$'
 				)
 			):
 				with m.If(self.s2):
@@ -963,7 +966,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^FSM State is not permitted outside of FSM \(test_dsl\.py, line \d+\)$'
+			r'^You are not allowed to use an \'m\.State\(\.\.\.\)\' outside of an \'m\.FSM\(\.\.\.\)\''
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.State('FOO'):
 				pass # :nocov:
@@ -974,7 +978,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 			with m.State('FOO'):
 				with self.assertRaisesRegex(
 					ToriiSyntaxError,
-					r'^FSM State is not permitted outside of FSM \(test_dsl\.py, line \d+\)$'
+					r'^You are not allowed to use an \'m\.State\(\.\.\.\)\' outside of an \'m\.FSM\(\.\.\.\)\''
+					r' \(test_dsl\.py, line \d+\)$'
 				):
 					with m.State('BAR'):
 						pass # :nocov:

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -109,6 +109,12 @@ class DSLTestCase(ToriiTestSuiteCase):
 		):
 			m.d.sync += Switch(self.s1, {})
 
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The object 1 is not a Torii statement \(test_dsl\.py, line \d+\)$'
+		):
+			m.d.sync += 1
+
 	def test_comb_wrong(self):
 		m = Module()
 		with self.assertRaisesRegex(

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -870,7 +870,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^FSM state \'FOO\' is referenced but not defined \(test_dsl\.py, line \d+\)$'
+			r'^The specified FSM state \'FOO\' was not found in the FSM \'fsm\' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.FSM() as fsm:
 				fsm.ongoing('FOO')

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -127,13 +127,22 @@ class DSLTestCase(ToriiTestSuiteCase):
 
 	def test_d_suspicious(self):
 		m = Module()
-		with self.assertWarnsRegex(
-			ToriiSyntaxWarning, (
-				r'^Using \'<module>\.d\.submodules\' would add statements to clock domain '
-				r'\'submodules\'; did you mean <module>\.submodules instead\?$'
-			)
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The clock domain \'submodules\' does not exist and is explicitly disallowed;'
+			r' you likely meant \'<module>.submodules\' instead of \'<module>.d.submodules\''
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			m.d.submodules += []
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^The clock domain \'submodule\' does not exist and is explicitly disallowed;'
+			r' you likely meant \'<module>.submodules\' instead of \'<module>.d.submodule\''
+			r' \(test_dsl\.py, line \d+\)$'
+		):
+			m.d.submodule += []
 
 	def test_clock_signal(self):
 		m = Module()

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -894,17 +894,20 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Only assignment to `m\.next` is permitted \(test_dsl\.py, line \d+\)$'
+			r'^The \'m\.next\' attribute is only assignable, and may only be used in the context of an FSM state'
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			m.next
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^`m\.next = <\.\.\.>` is only permitted inside an FSM state \(test_dsl\.py, line \d+\)$'
+			r'^Assignment to \'m\.next\' is only permitted from within the context of an FSM state'
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			m.next = 'FOO'
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^`m\.next = <\.\.\.>` is only permitted inside an FSM state \(test_dsl\.py, line \d+\)$'
+			r'^Assignment to \'m\.next\' is only permitted from within the context of an FSM state'
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.FSM():
 				m.next = 'FOO'

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -106,6 +106,13 @@ class DSLTestCase(ToriiTestSuiteCase):
 
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
+			r'^Direct assignment to \'d.pix\' is not supported, you likely meant to use \'\+=\' to'
+			r' add logic statements to the \'pix\' domain \(test_dsl\.py, line \d+\)$'
+		):
+			m.d['pix'] = None
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
 			r'^Clock domains can not be created through the \'m\.d\' accessor alias, use \'m\.domains\''
 			r' instead\. \(test_dsl\.py, line \d+\)$'
 		):

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -1124,12 +1124,14 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Only clock domains may be added to `m\.domains`, not 1 \(test_dsl\.py, line \d+\)$'
+			r'^Only Torii \'ClockDomain\'s may be added to the module domain list, not objects'
+			r' of type int \(test_dsl\.py, line \d+\)$'
 		):
 			m.domains.foo = 1
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Only clock domains may be added to `m\.domains`, not 1 \(test_dsl\.py, line \d+\)$'
+			r'^Only Torii \'ClockDomain\'s may be added to the module domain list, not objects'
+			r' of type int \(test_dsl\.py, line \d+\)$'
 		):
 			m.domains += 1
 
@@ -1137,8 +1139,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Clock domain name \'bar\' must match name in `m\.domains\.foo \+= \.\.\.` syntax '
-			r'\(test_dsl\.py, line \d+\)$'
+			r'^The name of the clock domain must match the name for the domain in the module when it is'
+			r' explicitly specified \(test_dsl\.py, line \d+\)$'
 		):
 			m.domains.foo = ClockDomain('bar')
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -407,7 +407,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^`if m\.If\(\.\.\.\):` does not work; use `with m\.If\(\.\.\.\)` \(test_dsl\.py, line \d+\)$'
+			r'^The Torii \'If\' cannot be used in a traditional Python \'if\' expression;'
+			r' use it as a context manager instead\. \(test_dsl\.py, line \d+\)$'
 		):
 			if m.If(0):
 				pass # :nocov:
@@ -415,13 +416,15 @@ class DSLTestCase(ToriiTestSuiteCase):
 			pass
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^`if m\.Elif\(\.\.\.\):` does not work; use `with m\.Elif\(\.\.\.\)` \(test_dsl\.py, line \d+\)$'
+			r'^The Torii \'Elif\' cannot be used in a traditional Python \'if\' expression;'
+			r' use it as a context manager instead\. \(test_dsl\.py, line \d+\)$'
 		):
 			if m.Elif(0):
 				pass # :nocov:
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^`if m\.Else\(\.\.\.\):` does not work; use `with m\.Else\(\.\.\.\)` \(test_dsl\.py, line \d+\)$'
+			r'^The Torii \'Else\' cannot be used in a traditional Python \'if\' expression;'
+			r' use it as a context manager instead\. \(test_dsl\.py, line \d+\)$'
 		):
 			if m.Else():
 				pass # :nocov:

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -27,8 +27,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 	def test_cant_inherit(self):
 		with self.assertRaisesRegex(
 			ToriiSyntaxError, (
-				r'^Instead of inheriting from `Module`, inherit from `Elaboratable` and '
-				r'return a `Module` from the `elaborate\(self, platform\)` method \(test_dsl\.py, line \d+\)$'
+				r'^Instead of inheriting from \'Module\', inherit from \'Elaboratable\' and return'
+				r' a \'Module\' from the \'elaborate\(self, platform\)\' method \(test_dsl\.py, line \d+\)$'
 			)
 		):
 			class ORGate(Module):

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -327,7 +327,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 	def test_Elif_wrong(self):
 		m = Module()
 		with self.assertRaisesRegex(
-			ToriiSyntaxError, r'^Elif without preceding If \(test_dsl\.py, line \d+\)$'
+			ToriiSyntaxError,
+			r'^\'Elif\' without a preceding \'If\' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.Elif(self.s2):
 				pass # :nocov:
@@ -337,7 +338,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		with m.If(self.s1):
 			with self.assertRaisesRegex(
 				ToriiSyntaxError,
-				r'^Elif without preceding If \(test_dsl\.py, line \d+\)$'
+				r'^\'Elif\' without a preceding \'If\' \(test_dsl\.py, line \d+\)$'
 			):
 				with m.Elif(self.s2):
 					pass # :nocov:
@@ -346,7 +347,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Else without preceding If\/Elif \(test_dsl\.py, line \d+\)$'
+			r'^\'Else\' without a preceding \'If\' or \'Elif\' \(test_dsl\.py, line \d+\)$'
 		):
 			with m.Else():
 				pass # :nocov:
@@ -356,7 +357,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		with m.If(self.s1):
 			with self.assertRaisesRegex(
 				ToriiSyntaxError,
-				r'^Else without preceding If/Elif \(test_dsl\.py, line \d+\)$'
+				r'^\'Else\' without a preceding \'If\' or \'Elif\' \(test_dsl\.py, line \d+\)$'
 			):
 				with m.Else():
 					pass # :nocov:
@@ -368,7 +369,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		with m.Elif(self.s2):
 			with self.assertRaisesRegex(
 				ToriiSyntaxError,
-				r'^Elif without preceding If \(test_dsl\.py, line \d+\)$'
+				r'^\'Elif\' without a preceding \'If\' \(test_dsl\.py, line \d+\)$'
 			):
 				with m.Elif(self.s3):
 					pass # :nocov:
@@ -380,7 +381,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		with m.Else():
 			with self.assertRaisesRegex(
 				ToriiSyntaxError,
-				r'^Else without preceding If/Elif \(test_dsl\.py, line \d+\)$'
+				r'^\'Else\' without a preceding \'If\' or \'Elif\' \(test_dsl\.py, line \d+\)$'
 			):
 				with m.Else():
 					pass # :nocov:

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -885,7 +885,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 				pass
 			with self.assertRaisesRegex(
 				ToriiSyntaxError,
-				r'^FSM state \'FOO\' is already defined \(test_dsl\.py, line \d+\)$'
+				r'^The FSM state \'FOO\' has already been defined previously \(test_dsl\.py, line \d+\)$'
 			):
 				with m.State('FOO'):
 					pass # :nocov:

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -115,7 +115,8 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Only assignments and property checks may be appended to d\.sync \(test_dsl\.py, line \d+\)$'
+			r'^Only Torii assignment and property check statements may be added to a logic domain'
+			r' \(test_dsl\.py, line \d+\)$'
 		):
 			m.d.sync += Switch(self.s1, {})
 

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -6,7 +6,7 @@ from collections       import OrderedDict
 from enum              import Enum
 from sys               import version_info
 
-from torii.diagnostics import ToriiSyntaxError, ToriiSyntaxWarning
+from torii.diagnostics import DriverConflictError, ToriiSyntaxError, ToriiSyntaxWarning
 from torii.hdl.ast     import Cat, ClockSignal, Past, ResetSignal, Signal, SignalSet, Switch
 from torii.hdl.cd      import ClockDomain
 from torii.hdl.dsl     import Module
@@ -18,6 +18,7 @@ class DSLTestCase(ToriiTestSuiteCase):
 		self.s1 = Signal()
 		self.s2 = Signal()
 		self.s3 = Signal()
+		self.c0 = Signal()
 		self.c1 = Signal()
 		self.c2 = Signal()
 		self.c3 = Signal()
@@ -76,13 +77,22 @@ class DSLTestCase(ToriiTestSuiteCase):
 
 	def test_d_conflict(self):
 		m = Module()
+		m.domains.phy = ClockDomain()
+
 		with self.assertRaisesRegex(
-			ToriiSyntaxError, (
-				r'^Driver-driver conflict: trying to drive \(sig c1\) from clock domain \'sync\', but it '
-				r'is already driven from the clock domain \'comb\' \(test_dsl\.py, line \d+\)$'
-			)
+			DriverConflictError,
+			r'^The signal \'c0\' was attempted to be driven from both the combinatorial logic domain \'comb\''
+			r' and the synchronous logic domain \'sync\' which is forbidden$'
 		):
-			m.d.comb += self.c1.eq(1)
+			m.d.comb += self.c0.eq(1)
+			m.d.sync += self.c0.eq(1)
+
+		with self.assertRaisesRegex(
+			DriverConflictError,
+			r'^The signal \'c1\' was attempted to be driven from the clock domain \'sync\', however it was'
+			r' initially driven by the clock domain \'phy\'$'
+		):
+			m.d.phy += self.c1.eq(1)
 			m.d.sync += self.c1.eq(1)
 
 	def test_d_wrong(self):

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -997,6 +997,21 @@ class DSLTestCase(ToriiTestSuiteCase):
 		):
 			m.submodules['\0'] = Module()
 
+	def test_submodule_name_forbidden(self) -> None:
+		m = Module()
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodule\' for a submodule is forbidden \(test_dsl\.py, line \d+\)$'
+		):
+			m.submodules['submodule'] = Module()
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Using the name \'submodules\' for a submodule is forbidden \(test_dsl\.py, line \d+\)$'
+		):
+			m.submodules['submodules'] = Module()
+
 	def test_submodule_wrong(self):
 		m = Module()
 		with self.assertRaisesRegex(

--- a/tests/hdl/test_dsl.py
+++ b/tests/hdl/test_dsl.py
@@ -89,9 +89,17 @@ class DSLTestCase(ToriiTestSuiteCase):
 		m = Module()
 		with self.assertRaisesRegex(
 			ToriiSyntaxError,
-			r'^Cannot assign \'d\.pix\' attribute; did you mean \'d.pix \+=\'\? \(test_dsl\.py, line \d+\)$'
+			r'^Direct assignment to \'d.pix\' is not supported, you likely meant to use \'\+=\' to'
+			r' add logic statements to the \'pix\' domain \(test_dsl\.py, line \d+\)$'
 		):
 			m.d.pix = None
+
+		with self.assertRaisesRegex(
+			ToriiSyntaxError,
+			r'^Clock domains can not be created through the \'m\.d\' accessor alias, use \'m\.domains\''
+			r' instead\. \(test_dsl\.py, line \d+\)$'
+		):
+			m.d.nya = ClockDomain()
 
 	def test_d_asgn_wrong(self):
 		m = Module()

--- a/torii/diagnostics/__init__.py
+++ b/torii/diagnostics/__init__.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from .errors   import (
-	AttributeError, ConstraintError, DomainError, IndexError, NameError, NameNotFound, NonSynthesizableError,
-	PlatformError, ResourceError, ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
+	AttributeError, ConstraintError, DomainError, DriverConflictError, IndexError, NameError, NameNotFound,
+	NonSynthesizableError, PlatformError, ResourceError, ToolError, ToolNotFound, ToriiError, ToriiSyntaxError,
+	YosysError,
 )
 from .warnings import (
 	ConstraintWarning, DriverConflict, MustUseWarning, NameWarning, PlatformWarning, ResourceWarning, ToolWarning,
@@ -15,6 +16,7 @@ __all__ = (
 	'ConstraintWarning',
 	'DomainError',
 	'DriverConflict',
+	'DriverConflictError',
 	'IndexError',
 	'MustUseWarning',
 	'NameError',

--- a/torii/diagnostics/__init__.py
+++ b/torii/diagnostics/__init__.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from .errors   import (
-	ConstraintError, DomainError, IndexError, NameError, NameNotFound, NonSynthesizableError, PlatformError,
-	ResourceError, ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
+	AttributeError, ConstraintError, DomainError, IndexError, NameError, NameNotFound, NonSynthesizableError,
+	PlatformError, ResourceError, ToolError, ToolNotFound, ToriiError, ToriiSyntaxError, YosysError,
 )
 from .warnings import (
 	ConstraintWarning, DriverConflict, MustUseWarning, NameWarning, PlatformWarning, ResourceWarning, ToolWarning,
@@ -10,6 +10,7 @@ from .warnings import (
 )
 
 __all__ = (
+	'AttributeError',
 	'ConstraintError',
 	'ConstraintWarning',
 	'DomainError',

--- a/torii/diagnostics/errors.py
+++ b/torii/diagnostics/errors.py
@@ -10,6 +10,7 @@ __all__ = (
 	'AttributeError',
 	'ConstraintError',
 	'DomainError',
+	'DriverConflictError',
 	'IndexError',
 	'NameError',
 	'NameNotFound',
@@ -124,4 +125,8 @@ class AttributeError(ToriiError, AttributeError):
 	This is used for where we wish to maintain proper functionality with things such as the
 	python :py:meth:`hasattr` call, but also if not caught emit a pretty Torii diagnostic
 	'''
+	pass
+
+class DriverConflictError(ToriiError):
+	''' A driver-driver conflict '''
 	pass

--- a/torii/diagnostics/errors.py
+++ b/torii/diagnostics/errors.py
@@ -7,6 +7,7 @@ from .._typing import SrcLoc
 '''
 
 __all__ = (
+	'AttributeError',
 	'ConstraintError',
 	'DomainError',
 	'IndexError',
@@ -114,4 +115,13 @@ class YosysError(ToolError):
 
 class IndexError(ToriiSyntaxError, IndexError):
 	'''  '''
+	pass
+
+class AttributeError(ToriiError, AttributeError):
+	'''
+	A hybrid between the Python :py:class:`AttributeError` and :py:class:`ToriiError`.
+
+	This is used for where we wish to maintain proper functionality with things such as the
+	python :py:meth:`hasattr` call, but also if not caught emit a pretty Torii diagnostic
+	'''
 	pass

--- a/torii/hdl/cd.py
+++ b/torii/hdl/cd.py
@@ -92,10 +92,21 @@ class ClockDomain:
 
 		if name.startswith('cd_'):
 			name = name[3:]
+
 		if name == 'comb':
 			raise ToriiSyntaxError(
 				'The combinatorial logic domain \'comb\' may not be clocked',
 				self.src_loc
+			)
+
+		if name in ('submodules', 'submodule'):
+			raise ToriiSyntaxError(
+				f'Using the name \'{name}\' for a clock domain is forbidden',
+				self.src_loc,
+				notes = [
+					f'Usage of \'{name}\' as a clock domain name introduces a potential confusion when dealing'
+					' with Torii submodules, as such it is explicitly forbidden'
+				]
 			)
 
 		if clk_edge not in ('pos', 'neg'):
@@ -138,6 +149,16 @@ class ClockDomain:
 				)
 
 			raise err
+
+		if new_name == 'submodules' or new_name == 'submodule':
+			raise ToriiSyntaxError(
+				f'Using the name \'{new_name}\' for a clock domain is forbidden',
+				self.src_loc,
+				notes = [
+					f'Usage of \'{new_name}\' as a clock domain name introduces a potential confusion when dealing'
+					' with Torii submodules, as such it is explicitly forbidden'
+				]
+			)
 
 		self.name = new_name
 		self.clk.name = self._name_for(new_name, 'clk')

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -234,8 +234,12 @@ class _GuardedContextManager(_GeneratorContextManager):
 
 	def __bool__(self):
 		raise ToriiSyntaxError(
-			f'`if m.{self.keyword}(...):` does not work; use `with m.{self.keyword}(...)`',
-			tracer.get_src_loc()
+			f'The Torii \'{self.keyword}\' cannot be used in a traditional Python \'if\' expression;'
+			f' use it as a context manager instead.',
+			tracer.get_src_loc(),
+			notes = [
+				f'Rather than \'if m.{self.keyword}(...):\', use \'with m.{self.keyword}(...):\''
+			]
 		)
 
 def _guardedcontextmanager(keyword: str):

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -606,7 +606,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 
 		if not patterns:
 			raise ToriiSyntaxError(
-				'Empty Case() clauses have been superseded by Default()',
+				'Empty\'m.Case()\' clauses are forbidden, use \'m.Default()\' instead for default/catch-all'
+				' cases',
 				tracer.get_src_loc(src_loc_at = 1)
 			)
 
@@ -619,10 +620,15 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			raise ToriiSyntaxError('Case outside of Switch block', tracer.get_src_loc(src_loc_at = 1))
 		new_patterns: SwitchCaseT = ()
 		if () in switch_data['cases']:
-			warnings.warn(
-				'Case statements are order-dependant, any Case after a Default will be ignored',
-				ToriiSyntaxWarning, stacklevel = 3
+			warning = ToriiSyntaxWarning(
+				'Any \'m.Case(...)\' statements after an \'m.Default()\' will be ignored'
 			)
+
+			warning.add_note(
+				'Unlike other languages, in Torii case statements are evaluated strictly in-order'
+			)
+
+			warnings.warn(warning, stacklevel = 3)
 
 		# This code should accept exactly the same patterns as `v.matches(...)`.
 		for pattern in patterns:

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -62,16 +62,18 @@ class _ModuleBuilderDomains(_ModuleBuilderProxy):
 	'''
 
 	def __getattr__(self, name: str):
-		if name == 'submodules':
-			warnings.warn(
-				f'Using \'<module>.d.{name}\' would add statements to clock domain {name!r}; '
-				f'did you mean <module>.{name} instead?',
-				ToriiSyntaxWarning, stacklevel = 2
+		if name in ('submodule', 'submodules'):
+			raise ToriiSyntaxError(
+				f'The clock domain \'{name}\' does not exist and is explicitly disallowed;'
+				f' you likely meant \'<module>.submodules\' instead of \'<module>.d.{name}\'',
+				tracer.get_src_loc()
 			)
+
 		if name == 'comb':
 			domain = None
 		else:
 			domain = name
+
 		return _ModuleBuilderDomain(self._builder, self._depth, domain)
 
 	def __getitem__(self, name):

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -492,10 +492,21 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if TYPE_CHECKING:
 			assert if_data is None or isinstance(if_data, _IfDict)
 		if if_data is None or if_data['depth'] != self.domain._depth:
-			err = ToriiSyntaxError('Elif without preceding If', tracer.get_src_loc(src_loc_at = 1))
+			err = ToriiSyntaxError('\'Elif\' without a preceding \'If\'', src_loc)
 			if if_data is not None and if_data['depth'] < self.domain._depth:
-				err.add_note(f'There is an If defined on line {if_data["src_loc"][1]}, is the Elif over-indented?')
+				# If the `m.If` is within 5 lines, we don't need to add a new context window
+				if abs(src_loc[1] - if_data['src_loc'][1]) <= 5:
+					err.add_note(
+						f'There is an \'If\' defined on line {if_data["src_loc"][1]}, is this \'Elif\' over-indented?'
+					)
+				else:
+					err.additional_ctx = (
+						'There is an \'If\' defined in the scope above this one, is this \'Elif\' over-indented?',
+						if_data["src_loc"]
+					)
+
 			raise err
+
 		_outer_case = self._statements
 		try:
 			self._statements = Statement.cast([])
@@ -521,10 +532,23 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if TYPE_CHECKING:
 			assert if_data is None or isinstance(if_data, _IfDict)
 		if if_data is None or if_data['depth'] != self.domain._depth:
-			err = ToriiSyntaxError('Else without preceding If/Elif', src_loc)
+			err = ToriiSyntaxError('\'Else\' without a preceding \'If\' or \'Elif\'', src_loc)
 			if if_data is not None and if_data['depth'] < self.domain._depth:
-				err.add_note(f'There is an If/Elif defined on line {if_data["src_loc"][1]}, is the Else over-indented?')
+				# If the `m.If` is within 5 lines, we don't need to add a new context window
+				if abs(src_loc[1] - if_data['src_loc'][1]) <= 5:
+					err.add_note(
+						f'There is an \'If\' or \'Elif\' defined on line {if_data["src_loc"][1]},'
+						' is this \'Else\' over-indented?'
+					)
+				else:
+					err.additional_ctx = (
+						'There is an \'If\' or \'Elif\' defined in the scope above this one, is this'
+						' \'Elif\' over-indented?',
+						if_data["src_loc"]
+					)
+
 			raise err
+
 		_outer_case = self._statements
 		try:
 			self._statements = Statement.cast([])

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -10,7 +10,7 @@ from functools       import wraps
 from sys             import version_info
 from typing          import TYPE_CHECKING, Any, ParamSpec, TypedDict
 
-from ..diagnostics   import ToriiSyntaxError, ToriiSyntaxWarning
+from ..diagnostics   import DriverConflictError, ToriiSyntaxError, ToriiSyntaxWarning
 from .._typing       import SrcLoc, SwitchCaseT
 from ..util          import _check_name, flatten, tracer
 from ..util.string   import _get_best_matching
@@ -927,11 +927,37 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					self._driving[signal] = domain
 				elif self._driving[signal] != domain:
 					cd_curr = self._driving[signal]
-					raise ToriiSyntaxError(
-						f'Driver-driver conflict: trying to drive {signal!r} from clock domain '
-						f'\'{domain_name(domain)}\', but it is already driven from the clock domain '
-						f'\'{domain_name(cd_curr)}\'',
-						tracer.get_src_loc(src_loc_at = src_loc_at)
+					src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
+
+					new_driver = domain_name(domain)
+					old_driver = domain_name(cd_curr)
+
+					if 'comb' in (new_driver, old_driver):
+						sync_name = new_driver if old_driver == 'comb' else old_driver
+
+						message = (
+							f'The signal \'{signal.name}\' was attempted to be driven from both the combinatorial logic'
+							f' domain \'comb\' and the synchronous logic domain \'{sync_name}\' which is forbidden'
+						)
+						notes = [
+							'It is nonsensical to drive a synchronous signal from the combinatorial domain,'
+							' was this logic supposed to be in the synchronous domain?'
+						]
+					else:
+						message = (
+							f'The signal \'{signal.name}\' was attempted to be driven from the clock domain'
+							f' \'{new_driver}\', however it was initially driven by the clock domain \'{old_driver}\''
+						)
+						notes = [
+							'You may not drive a signal from multiple clock domains at once, consider using'
+							' a synchronizer from \'torii.lib.cdc\' to cross clock domains where appropriate'
+						]
+
+					raise DriverConflictError(
+						message = message, src_loc = src_loc, notes = notes, additional_ctx = (
+							f'The signal \'{signal.name}\' was first driven by the domain \'{old_driver}\' here:',
+							self._driving_locs[cd_curr]
+						)
 					)
 
 			self._statements.append(stmt)

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -756,10 +756,45 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			yield fsm
 			for state_name in fsm_data['encoding']:
 				if state_name not in fsm_data['states']:
+					matches = _get_best_matching(state_name, fsm_data['states'].keys())
+					notes = None
+					additional_ctx = None
+
+					if len(matches) > 0:
+						match = matches.pop()
+						message = (
+							f'The FSM state \'{state_name}\' did not match any existing states in the FSM'
+							f' \'{fsm_data["name"]}\', did you mean \'{match}\'?'
+						)
+
+						if len(matches) > 0:
+							additional_matches = ', '.join(map(lambda m: f'\'{m}\'', matches))
+							notes = [
+								f'Additional possible matches for \'{state_name}\' are: {additional_matches}'
+							]
+
+						additional_ctx = (
+							f'The state \'{match}\' was defined here:',
+							fsm_data['state_src_locs'][match]
+						)
+					else:
+						message = (
+							f'The specified FSM state \'{state_name}\' was not found in the FSM'
+							f' \'{fsm_data["name"]}\''
+						)
+
+					if state_name in fsm_data['state_visit_map']:
+						src_loc = fsm_data['state_visit_map'][state_name][1]
+					else:
+						src_loc = tracer.get_src_loc(src_loc_at = 1)
+
 					raise ToriiSyntaxError(
-						f'FSM state \'{state_name}\' is referenced but not defined',
-						tracer.get_src_loc(src_loc_at = 1)
+						message = message,
+						src_loc = src_loc,
+						notes = notes,
+						additional_ctx = additional_ctx
 					)
+
 		finally:
 			self.domain._depth -= 1
 			self._ctrl_context = None

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -333,8 +333,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 	@classmethod
 	def __init_subclass__(cls):
 		raise ToriiSyntaxError(
-			'Instead of inheriting from `Module`, inherit from `Elaboratable` '
-			'and return a `Module` from the `elaborate(self, platform)` method',
+			'Instead of inheriting from \'Module\', inherit from \'Elaboratable\''
+			' and return a \'Module\' from the \'elaborate(self, platform)\' method',
 			tracer.get_src_loc(src_loc_at = 1)
 		)
 

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -117,12 +117,44 @@ class _ModuleBuilderRoot:
 	def __getattr__(self, name):
 		if name in ('comb', 'sync'):
 			raise ToriiSyntaxError(
-				f'\'{type(self).__name__}\' object has no attribute \'{name}\'; did you mean \'d.{name}\'?',
-				tracer.get_src_loc()
+				'Access to the combinatorial logic domain \'comb\' and clock domains like \'sync\' must be done'
+				' through the \'d\' attribute on the module',
+				tracer.get_src_loc(),
+				notes = [
+					f'It appears like you meant to do \'m.d.{name}\' rather than \'m.{name}\''
+				]
 			)
+
+		# NOTE(aki): We don't have `d` in here because it throws off the heuristics
+		matches = _get_best_matching(name, [
+			'Case', 'Default', 'domain', 'domains', 'Elif', 'Else', 'FSM', 'has_submodules', 'If',
+			'next', 'State', 'submodules', 'Switch', *self._builder._named_submodules.keys()
+		])
+
+		if len(matches) > 0:
+			match = matches.pop(0)
+
+			if match in self._builder._named_submodules:
+				message = (
+					f'Module has no attribute named \'{name}\', however there is a named submodule called'
+					f' \'{match}\', did you mean to do \'m.submodules.{match}\'?'
+				)
+			else:
+				message = f'Module has no attribute named \'{name}\', did you mean \'{match}\'?'
+
+			if len(matches) > 0:
+				additional_matches = ', '.join(map(lambda m: f'\'{m}\'', matches))
+				notes = [
+					f'Additional possible matches for \'{name}\' are: {additional_matches}'
+				]
+			else:
+				notes = []
+		else:
+			message = f'Module has no attribute named \'{name}\''
+			notes = []
+
 		raise ToriiSyntaxError(
-			f'\'{type(self).__name__}\' object has no attribute \'{name}\'',
-			tracer.get_src_loc()
+			message = message, src_loc = tracer.get_src_loc(), notes = notes
 		)
 
 class _ModuleBuilderSubmodules:

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -875,7 +875,10 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		.. todo:: Document Me
 		'''
 
-		raise ToriiSyntaxError('Only assignment to `m.next` is permitted', tracer.get_src_loc())
+		raise ToriiSyntaxError(
+			'The \'m.next\' attribute is only assignable, and may only be used in the context of an FSM state',
+			tracer.get_src_loc()
+		)
 
 	@next.setter
 	def next(self, name):
@@ -900,7 +903,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					return
 
 		raise ToriiSyntaxError(
-			'`m.next = <...>` is only permitted inside an FSM state',
+			'Assignment to \'m.next\' is only permitted from within the context of an FSM state',
 			tracer.get_src_loc()
 		)
 

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -1011,7 +1011,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					)
 				self._named_submodules[name] = submodule
 
-	def _get_submodule(self, name: str):
+	def _get_submodule(self, name: str, *, src_loc_at: int = 1):
 		'''
 		.. todo:: Document Me
 		'''
@@ -1019,9 +1019,32 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if name in self._named_submodules:
 			return self._named_submodules[name]
 		else:
+			matches = _get_best_matching(name, self._named_submodules.keys())
+			if len(matches) > 0:
+				match = matches.pop(0)
+				message = (
+					f'The submodule named \'{name}\' does not exist in the current module, did you mean'
+					f' \'{match}\'?'
+				)
+				notes = []
+
+				if len(matches) > 0:
+					additional_matches = ', '.join(map(lambda m: f'\'{m}\'', matches))
+					notes.append(
+						f'Additional possible matches for \'{name}\' are: {additional_matches}'
+					)
+
+				notes.append(
+					'If not, did you accidentally add it as an anonymous submodule? (e.g \'m.submodules += ...\')'
+				)
+			else:
+				message = f'The submodule named \'{name}\' does not exist in the current module'
+				notes = [
+					'Did you accidentally add it as an anonymous submodule? (e.g \'m.submodules += ...\')'
+				]
+
 			raise ToriiSyntaxError(
-				f'No submodule named \'{name}\' exists',
-				tracer.get_src_loc(src_loc_at = 1)
+				message = message, src_loc = tracer.get_src_loc(src_loc_at = src_loc_at), notes = notes
 			)
 
 	def _add_domain(self, cd: ClockDomain):

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -80,10 +80,16 @@ class _ModuleBuilderDomains(_ModuleBuilderProxy):
 		return self.__getattr__(name)
 
 	def __setattr__(self, name, value):
+		return self._setattr_proxy(name, value)
+
+	def __setitem__(self, name, value):
+		return self._setattr_proxy(name, value)
+
+	def _setattr_proxy(self, name, value, *, src_loc_at: int = 1):
 		if name == '_depth':
 			object.__setattr__(self, name, value)
 		elif not isinstance(value, _ModuleBuilderDomain):
-			src_loc = tracer.get_src_loc()
+			src_loc = tracer.get_src_loc(src_loc_at = src_loc_at)
 
 			if isinstance(value, ClockDomain):
 				raise ToriiSyntaxError(
@@ -101,9 +107,6 @@ class _ModuleBuilderDomains(_ModuleBuilderProxy):
 				f' add logic statements to the \'{name}\' domain',
 				src_loc
 			)
-
-	def __setitem__(self, name, value):
-		return self.__setattr__(name, value)
 
 class _ModuleBuilderRoot:
 	'''

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -83,9 +83,23 @@ class _ModuleBuilderDomains(_ModuleBuilderProxy):
 		if name == '_depth':
 			object.__setattr__(self, name, value)
 		elif not isinstance(value, _ModuleBuilderDomain):
+			src_loc = tracer.get_src_loc()
+
+			if isinstance(value, ClockDomain):
+				raise ToriiSyntaxError(
+					'Clock domains can not be created through the \'m.d\' accessor alias, use \'m.domains\''
+					' instead.',
+					src_loc,
+					notes = [
+						f'Rather than writing \'m.d.{name} = ClockDomain()\' use the full '
+						f'\'m.domains.{name} = ClockDomain()\' syntax',
+					]
+				)
+
 			raise ToriiSyntaxError(
-				f'Cannot assign \'d.{name}\' attribute; did you mean \'d.{name} +=\'?',
-				tracer.get_src_loc()
+				f'Direct assignment to \'d.{name}\' is not supported, you likely meant to use \'+=\' to'
+				f' add logic statements to the \'{name}\' domain',
+				src_loc
 			)
 
 	def __setitem__(self, name, value):

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -904,6 +904,15 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					'`name` parameter or explicitly set it to `None`',
 					tracer.get_src_loc(src_loc_at = 2)
 				)
+			case 'submodule' | 'submodules':
+				raise ToriiSyntaxError(
+					f'Using the name \'{name}\' for a submodule is forbidden',
+					tracer.get_src_loc(src_loc_at = 2),
+					notes = [
+						f'Due to introducing confusion, usage of the name \'{name}\' for submodules is explicitly'
+						f' forbidden. Consider use the snake_case name for \'{type(submodule).__name__}\' instead.'
+					]
+				)
 			case _:
 				if not _check_name(name):
 					raise ToriiSyntaxError(

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -891,7 +891,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 
 	def _add_statement(
 		self, assigns, domain: str, depth, compat_mode = False, domain_loc: tuple[str, int] | None = None,
-		src_loc_at: int = 0
+		*, src_loc_at: int = 1
 	):
 		'''
 		.. todo:: Document Me
@@ -900,7 +900,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		# Store the very first driving reference
 		if domain not in self._driving_locs:
 			self._driving_locs[domain] = (
-				tracer.get_src_loc(src_loc_at = 1) if domain_loc is None else domain_loc
+				tracer.get_src_loc(src_loc_at = src_loc_at) if domain_loc is None else domain_loc
 			)
 
 		def domain_name(domain):
@@ -912,11 +912,11 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		while len(self._ctrl_stack) > self.domain._depth:
 			self._pop_ctrl()
 
-		for stmt in Statement.cast(assigns, src_loc_at = src_loc_at + 1):
+		for stmt in Statement.cast(assigns, src_loc_at = 1 + src_loc_at):
 			if not compat_mode and not isinstance(stmt, (Assign, Property)):
 				raise ToriiSyntaxError(
 					f'Only assignments and property checks may be appended to d.{domain_name(domain)}',
-					tracer.get_src_loc(src_loc_at = 1)
+					tracer.get_src_loc(src_loc_at = src_loc_at)
 				)
 
 			stmt._MustUse__used = True
@@ -931,7 +931,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 						f'Driver-driver conflict: trying to drive {signal!r} from clock domain '
 						f'\'{domain_name(domain)}\', but it is already driven from the clock domain '
 						f'\'{domain_name(cd_curr)}\'',
-						tracer.get_src_loc(src_loc_at = 1)
+						tracer.get_src_loc(src_loc_at = src_loc_at)
 					)
 
 			self._statements.append(stmt)

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -914,8 +914,11 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 
 		for stmt in Statement.cast(assigns, src_loc_at = 1 + src_loc_at):
 			if not compat_mode and not isinstance(stmt, (Assign, Property)):
+				# TODO(aki):
+				# We should figure out what type of statement was and offer suggestions on how to transform
+				# said statement into valid Torii code
 				raise ToriiSyntaxError(
-					f'Only assignments and property checks may be appended to d.{domain_name(domain)}',
+					'Only Torii assignment and property check statements may be added to a logic domain',
 					tracer.get_src_loc(src_loc_at = src_loc_at)
 				)
 

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -311,7 +311,7 @@ class _FSMDict(TypedDict):
 	states: OrderedDict[str, _StatementList]
 	src_loc: SrcLoc
 	state_src_locs: dict[str, SrcLoc]
-	state_visit_map: dict[str, bool]
+	state_visit_map: dict[str, tuple[bool, SrcLoc]]
 
 _CtrlEntry = _IfDict | _SwitchDict | _FSMDict
 
@@ -793,7 +793,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			if len(fsm_data['states']) == 0 and fsm_data['reset'] is None:
 				# If we are the first state in this FSM /and/ the reset state is not specified then
 				# we are the reset state and are by-default visited
-				fsm_data['state_visit_map'][name] = True
+				fsm_data['state_visit_map'][name] = (True, src_loc)
 			fsm_data['states'][name] = self._statements
 			fsm_data['state_src_locs'][name] = src_loc
 		finally:
@@ -821,7 +821,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 						assert isinstance(ctrl_data, _FSMDict)
 					if name not in ctrl_data['encoding']:
 						ctrl_data['encoding'][name] = len(ctrl_data['encoding'])
-					ctrl_data['state_visit_map'][name] = True
+					ctrl_data['state_visit_map'][name] = (True, tracer.get_src_loc(src_loc_at = 1))
 					self._add_statement(
 						assigns    = [ ctrl_data['signal'].eq(ctrl_data['encoding'][name]) ],
 						domain     = ctrl_data['domain'],

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -834,8 +834,22 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if fsm_data is None:
 			raise ToriiSyntaxError('State outside of FSM block', tracer.get_src_loc(src_loc_at = 1))
 		if name in fsm_data['states']:
-			err = ToriiSyntaxError(f'FSM state \'{name}\' is already defined', src_loc)
-			err.add_note(f'\'{name}\' was previously defined on line {fsm_data["state_src_locs"][name][1]}')
+			err = ToriiSyntaxError(
+				f'The FSM state \'{name}\' has already been defined previously',
+				src_loc
+			)
+
+			# If the state is within 5 lines wwe don't need a new context window
+			if abs(src_loc[1] - fsm_data['src_loc'][1]) <= 5:
+				err.add_note(
+					f'The state \'{name}\' was previously defined on line {fsm_data["state_src_locs"][name][1]}'
+				)
+			else:
+				err.additional_ctx = (
+					f'The state \'{name}\' was previously defined here:',
+					fsm_data['state_src_locs'][name]
+				)
+
 			raise err
 		if name not in fsm_data['encoding']:
 			fsm_data['encoding'][name] = len(fsm_data['encoding'])

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -400,17 +400,21 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if self._ctrl_context != context:
 			if self._ctrl_context is None:
 				raise ToriiSyntaxError(
-					f'{construct} is not permitted outside of {context}',
+					f'You are not allowed to use an \'m.{construct}(...)\' outside of an \'m.{context}(...)\'',
 					tracer.get_src_loc(src_loc_at = 2)
 				)
 			else:
-				if self._ctrl_context == 'Switch':
-					secondary_context = 'Case'
-				if self._ctrl_context == 'FSM':
-					secondary_context = 'State'
+				match self._ctrl_context:
+					case 'Switch':
+						secondary_context = 'Case'
+					case 'FSM':
+						secondary_context = 'State'
+					case _:
+						secondary_context = 'Unknown'
+
 				raise ToriiSyntaxError(
-					f'{construct} is not permitted directly inside of {self._ctrl_context}; '
-					f'it is permitted inside of {self._ctrl_context} {secondary_context}',
+					f'An \'m.{construct}(...)\' is not permitted directly inside of an \'m.{self._ctrl_context}(...)\';'
+					f' it is only permitted inside of a(n) {self._ctrl_context}s \'m.{secondary_context}(...)\'',
 					tracer.get_src_loc(src_loc_at = 2)
 				)
 
@@ -816,7 +820,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		.. todo:: Document Me
 		'''
 
-		self._check_context('FSM State', context = 'FSM')
+		self._check_context('State', context = 'FSM')
 		src_loc = tracer.get_src_loc(src_loc_at = 1)
 		fsm_data = self._get_ctrl('FSM')
 		if TYPE_CHECKING:

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -904,14 +904,21 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			else:
 				src_loc = data['src_loc']
 				matches = _get_best_matching(fsm_reset, fsm_states.keys())
+				notes = None
 				additional_ctx = None
 
 				if len(matches) > 0:
-					match = matches[0]
+					match = matches.pop()
 					message = (
 						f'The specified reset state \'{fsm_reset}\' did not match any existing states in the FSM '
 						f'\'{fsm_name}\', did you mean \'{match}\'?'
 					)
+
+					if len(matches) > 0:
+						additional_matches = ', '.join(map(lambda m: f'\'{m}\'', matches))
+						notes = [
+							f'Additional possible matches for \'{fsm_reset}\' are: {additional_matches}'
+						]
 
 					additional_ctx = (
 						f'The state \'{match}\' was defined here:',
@@ -921,7 +928,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 					message = f'The specified reset state \'{fsm_reset}\' does not exist inside the FSM \'{fsm_name}\''
 
 				raise ToriiSyntaxError(
-					message = message, src_loc = src_loc, additional_ctx = additional_ctx
+					message = message, src_loc = src_loc, notes = notes, additional_ctx = additional_ctx
 				)
 			# The FSM is encoded such that the state with encoding 0 is always the reset state.
 			fsm_decoding.update((n, s) for s, n in fsm_encoding.items())

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -201,23 +201,33 @@ class _ModuleBuilderDomainSet:
 		for domain in flatten([domains]):
 			if not isinstance(domain, ClockDomain):
 				raise ToriiSyntaxError(
-					f'Only clock domains may be added to `m.domains`, not {domain!r}',
+					'Only Torii \'ClockDomain\'s may be added to the module domain list, not objects of type'
+					f' {type(domain).__name__}',
 					tracer.get_src_loc()
 				)
+
 			self._builder._add_domain(domain)
 		return self
 
 	def __setattr__(self, name, domain):
 		if not isinstance(domain, ClockDomain):
 			raise ToriiSyntaxError(
-				f'Only clock domains may be added to `m.domains`, not {domain!r}',
+				'Only Torii \'ClockDomain\'s may be added to the module domain list, not objects of type'
+				f' {type(domain).__name__}',
 				tracer.get_src_loc()
 			)
+
 		if domain.name != name:
 			raise ToriiSyntaxError(
-				f'Clock domain name {domain.name!r} must match name in `m.domains.{name} += ...` syntax',
-				tracer.get_src_loc()
+				'The name of the clock domain must match the name for the domain in the module when it is'
+				' explicitly specified',
+				tracer.get_src_loc(),
+				notes = [
+					f'The clock domain is named \'{domain.name}\', where as the destination domain is called'
+					f' {name}'
+				]
 			)
+
 		self._builder._add_domain(domain)
 
 Params = ParamSpec('Params')

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -175,8 +175,8 @@ class _ModuleBuilderSubmodules:
 	def __setattr__(self, name, submodule):
 		self._builder._add_submodule(submodule, name)
 
-	def __setitem__(self, name, value):
-		return self.__setattr__(name, value)
+	def __setitem__(self, name, submodule):
+		self._builder._add_submodule(submodule, name)
 
 	def __getattr__(self, name):
 		return self._builder._get_submodule(name)
@@ -965,7 +965,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 
 			self._statements.append(stmt)
 
-	def _add_submodule(self, submodule, name = None):
+	def _add_submodule(self, submodule, name = None, *, src_loc_at: int = 1):
 		'''
 		.. todo:: Document Me
 		'''
@@ -973,7 +973,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 		if not hasattr(submodule, 'elaborate'):
 			raise ToriiSyntaxError(
 				f'Trying to add {submodule!r}, which does not implement .elaborate(), as a submodule',
-				tracer.get_src_loc(src_loc_at = 1)
+				tracer.get_src_loc(src_loc_at = src_loc_at)
 			)
 
 		match name:
@@ -983,12 +983,12 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 				raise ToriiSyntaxError(
 					'A submodule name must not be empty if provided, to add an anonymous submodule either omit the '
 					'`name` parameter or explicitly set it to `None`',
-					tracer.get_src_loc(src_loc_at = 2)
+					tracer.get_src_loc(src_loc_at = src_loc_at)
 				)
 			case 'submodule' | 'submodules':
 				raise ToriiSyntaxError(
 					f'Using the name \'{name}\' for a submodule is forbidden',
-					tracer.get_src_loc(src_loc_at = 2),
+					tracer.get_src_loc(src_loc_at = src_loc_at),
 					notes = [
 						f'Due to introducing confusion, usage of the name \'{name}\' for submodules is explicitly'
 						f' forbidden. Consider use the snake_case name for \'{type(submodule).__name__}\' instead.'
@@ -998,13 +998,13 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 				if not _check_name(name):
 					raise ToriiSyntaxError(
 						'Submodule name must not contain any control or whitespace characters',
-						tracer.get_src_loc(src_loc_at = 2)
+						tracer.get_src_loc(src_loc_at = src_loc_at)
 					)
 
 				if name in self._named_submodules:
 					raise ToriiSyntaxError(
 						f'Submodule named \'{name}\' already exists',
-						tracer.get_src_loc(src_loc_at = 1)
+						tracer.get_src_loc(src_loc_at = src_loc_at)
 					)
 				self._named_submodules[name] = submodule
 

--- a/torii/hdl/dsl.py
+++ b/torii/hdl/dsl.py
@@ -328,6 +328,43 @@ class Module(_ModuleBuilderRoot, Elaboratable):
 			tracer.get_src_loc(src_loc_at = 1)
 		)
 
+	def __setattr__(self, name: str, value: Any) -> None:
+		if name == 'domains' and not isinstance(value, _ModuleBuilderDomainSet):
+			err = ToriiSyntaxError(
+				'The value of \'m.domains\' may not be changed',
+				tracer.get_src_loc()
+			)
+
+			if isinstance(value, ClockDomain):
+				err.add_note(
+					f'Did you mean to do "m.domains += ClockDomain(\'{value.name}\')"?'
+				)
+
+			raise err
+
+		if name == 'submodules' and not isinstance(value, _ModuleBuilderSubmodules):
+			err = ToriiSyntaxError(
+				'The value of \'m.submodules\' may not be changed',
+				tracer.get_src_loc()
+			)
+
+			if isinstance(value, (Fragment, Elaboratable, Module)):
+				err.add_note(
+					f'Did you mean to do \'m.submodules += {type(value).__name__}(...)\'?'
+				)
+
+			raise err
+
+		try:
+			object.__setattr__(self, name, value)
+		except Exception as err:
+			# If we have a syntax error from below, re-adjust the source locality information
+			if isinstance(err, (ToriiSyntaxError)):
+				src_loc = tracer.get_src_loc()
+				err.filename = src_loc[0]
+				err.lineno = src_loc[1]
+			raise err
+
 	def __init__(self) -> None:
 		super().__init__(builder = self, depth = 0)
 		self.submodules    = _ModuleBuilderSubmodules(self)

--- a/torii/hdl/ir.py
+++ b/torii/hdl/ir.py
@@ -194,7 +194,14 @@ class Fragment:
 				raise TypeError(f'Domain must be a \'ClockDomain\', not a \'{domain!r}\'')
 
 			if domain.name in self.domains:
-				raise ValueError(f'Domain \'{domain.name}\' already in the list of domains')
+				raise ToriiSyntaxError(
+					f'Clock domain named \'{domain.name}\' already exists',
+					domain.src_loc,
+					additional_ctx = (
+						f'The domain \'{domain.name}\' was previously defined here:',
+						self.domains[domain.name].src_loc
+					)
+				)
 
 			self.domains[domain.name] = domain
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR is the next batch of diagnostics cleanups and improvements following #148. Like that one, there is a whole bunch of updates and changes in here and I don't have screenshots of them as there are so many, but! This adds things like better source locality for statement warnings/errors, guarding against accidentally assigning directly to `m.domains` and `m.submodules` which would silently break code, and a whole bunch of other little improvements!


Here's hoping that I didn't break anything when it comes to IR generation :v

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-hdl/blob/main/CONTRIBUTING.md#ai-usage-policy
